### PR TITLE
Only reverse FGONG point data if it's written from surface to center

### DIFF
--- a/src/model/gyre_fgong_file.fpp
+++ b/src/model/gyre_fgong_file.fpp
@@ -127,7 +127,7 @@ contains
 
     close(unit)
 
-    var = var(:,n:1:-1)
+    if (ALL(var(1,2:) <= var(1,:SIZE(var, dim=2)))) var = var(:,n:1:-1)
 
     if (check_log_level('INFO')) then
        write(OUTPUT_UNIT, 130) 'Read', n, 'points'


### PR DESCRIPTION
The FGONG format doesn't specify whether the point data should be written from surface to center or from center to surface, so add a logical test to only reverse the order if the data is from surface to center (specifically, by testing whether `var(1)` is everywhere decreasing).

The style of the logical test tries to mimic the assertion of a monotonic abscissa. i.e.
````
 ASSERT 'ALL(x(2:) > x(:SIZE(x)-1))' failed at line 20 <gyre_r_interp:r_interp_t_>:
 Non-monotonic abscissa
````