### PR TITLE
Right-align character data

### DIFF
--- a/src/output/gyre_txt_writer.fpp
+++ b/src/output/gyre_txt_writer.fpp
@@ -264,7 +264,92 @@ contains
 
   $WRITE(i,integer,I_FORMAT)
   $WRITE(r,real(WP),R_FORMAT)
-  $WRITE(a,character(*),A_FORMAT)
+
+  !****
+
+  subroutine write_a_0 (this, name, data)
+
+    class(txt_writer_t), intent(inout) :: this
+    character(*), intent(in)           :: name
+    character(*), intent(in)           :: data
+
+    integer :: d
+
+    ! If necessary, allocate/reallocate arrays
+
+    if(this%n_s == 0) then
+       allocate(this%s_data(16))
+       allocate(this%s_names(16))
+    endif
+
+    this%n_s = this%n_s + 1
+
+    d = SIZE(this%s_names)
+
+    if(this%n_s > d) then
+       call reallocate(this%s_names, [2*d])
+       call reallocate(this%s_data, [2*d])
+    endif
+
+    ! Store the data
+
+    this%s_names(this%n_s) = rjust(name, FIELD_LEN)
+
+    write(this%s_data(this%n_s), A_FORMAT) rjust(data, FIELD_LEN)
+
+    this%c = this%c + 1
+
+    ! Finish
+
+    return
+
+  end subroutine write_a_0
+
+  !****
+
+  subroutine write_a_1 (this, name, data)
+
+    class(txt_writer_t), intent(inout) :: this
+    character(*), intent(in)           :: name
+    character(*), intent(in)           :: data(:)
+
+    integer :: d
+    integer :: k
+
+    ! If necessary, allocate/reallocate arrays
+
+    if(this%n_v == 0) then
+       this%n = SIZE(data)
+       allocate(this%v_data(this%n,16))
+       allocate(this%v_names(16))
+    else
+
+    endif
+
+    this%n_v = this%n_v + 1
+
+    d = SIZE(this%v_names)
+
+    if(this%n_v > d) then
+       call reallocate(this%v_names, [2*d])
+       call reallocate(this%v_data, [this%n,2*d])
+    endif
+
+    ! Store the data
+
+    this%v_names(this%n_v) = rjust(name, FIELD_LEN)
+
+    do k = 1, this%n
+       write(this%v_data(k,this%n_v), A_FORMAT) rjust(data(k), FIELD_LEN)
+    end do
+
+    this%c = this%c + 1
+
+    ! Finish
+
+    return
+
+  end subroutine write_a_1
 
   !****
   


### PR DESCRIPTION
Column headings and numeric data is right-aligned when written to text files, whereas character data is right-aligned. This occasionally creates output like
````
                        1                        2                        3                        4
                   M_star                   R_star                   L_star               freq_units
  0.1989000000000000E+034  0.6959894677000000E+011  0.3845997429000000E+034UHZ                      
...
````
which is difficult to read, for humans and machines alike.

This commit fixes the problem by applying the Fortran intrinsic `adjustr` to the character data, as is already done for the headers. I couldn't work out how to keep the character writer as part of the macro expansion so I've written it out in full (as is already the case for the complex number writer).