### PR TITLE
Fix order of variables in definition of GYRE Stellar Model format

### DIFF
--- a/doc/gsm-format.tex
+++ b/doc/gsm-format.tex
@@ -63,8 +63,8 @@ $r$               & \texttt{r}            & D & \texttt{H5T\_IEEE\_F64LE} & Radi
 $w$               & \texttt{w}            & D & \texttt{H5T\_IEEE\_F64LE} & $M_{r}/(\Mstar-M_{r})$ \\
 $L_{r}$           & \texttt{L\_r}         & D & \texttt{H5T\_IEEE\_F64LE} & Luminosity ($\erg\,\second^{-1}$) \\
 $P$               & \texttt{p}            & D & \texttt{H5T\_IEEE\_F64LE} & Total pressure ($\dyne\,\cm^{-2}$) \\
-$\rho$            & \texttt{rho}          & D & \texttt{H5T\_IEEE\_F64LE} & Density ($\gram\,\cm^{-3}$) \\
 $T$               & \texttt{T}            & D & \texttt{H5T\_IEEE\_F64LE} & Temperature ($\kelvin$) \\
+$\rho$            & \texttt{rho}          & D & \texttt{H5T\_IEEE\_F64LE} & Density ($\gram\,\cm^{-3}$) \\
 $N^{2}$           & \texttt{N2}           & D & \texttt{H5T\_IEEE\_F64LE} & Brunt-V\"ais\"al\"a frequency squared ($\second^{-2}$) \\
 $\Gamma_{1}$      & \texttt{Gamma\_1}      & D & \texttt{H5T\_IEEE\_F64LE} & $(\partial \ln P/\partial \ln \rho)_{\rm ad}$ \\
 $\nabla_{\rm ad}$  & \texttt{nabla\_ad}      & D & \texttt{H5T\_IEEE\_F64LE} & $(\diff \ln T/\diff \ln P)_{\rm ad}$ \\
@@ -99,8 +99,8 @@ $r$               & \texttt{r}            & D & \texttt{H5T\_IEEE\_F64LE} & Radi
 $M_{r}$           & \texttt{M\_r}            & D & \texttt{H5T\_IEEE\_F64LE} & Interior mass ($\gram$) \\
 $L_{r}$           & \texttt{L\_r}         & D & \texttt{H5T\_IEEE\_F64LE} & Luminosity ($\erg\,\second^{-1}$) \\
 $P$               & \texttt{P}            & D & \texttt{H5T\_IEEE\_F64LE} & Total pressure ($\dyne\,\cm^{-2}$) \\
-$\rho$            & \texttt{rho}          & D & \texttt{H5T\_IEEE\_F64LE} & Density ($\gram\,\cm^{-3}$) \\
 $T$               & \texttt{T}            & D & \texttt{H5T\_IEEE\_F64LE} & Temperature ($\kelvin$) \\
+$\rho$            & \texttt{rho}          & D & \texttt{H5T\_IEEE\_F64LE} & Density ($\gram\,\cm^{-3}$) \\
 $N^{2}$           & \texttt{N2}           & D & \texttt{H5T\_IEEE\_F64LE} & Brunt-V\"ais\"al\"a frequency squared ($\second^{-2}$) \\
 $\Gamma_{1}$      & \texttt{Gamma\_1}      & D & \texttt{H5T\_IEEE\_F64LE} & $(\partial \ln P/\partial \ln \rho)_{\rm ad}$ \\
 $\nabla_{\rm ad}$  & \texttt{nabla\_ad}      & D & \texttt{H5T\_IEEE\_F64LE} & $(\diff \ln T/\diff \ln P)_{\rm ad}$ \\
@@ -138,8 +138,8 @@ $r$               & \texttt{r}            & D & \texttt{H5T\_IEEE\_F64LE} & Radi
 $M_{r}$           & \texttt{M\_r}            & D & \texttt{H5T\_IEEE\_F64LE} & Interior mass ($\gram$) \\
 $L_{r}$           & \texttt{L\_r}         & D & \texttt{H5T\_IEEE\_F64LE} & Luminosity ($\erg\,\second^{-1}$) \\
 $P$               & \texttt{P}            & D & \texttt{H5T\_IEEE\_F64LE} & Total pressure ($\dyne\,\cm^{-2}$) \\
-$\rho$            & \texttt{rho}          & D & \texttt{H5T\_IEEE\_F64LE} & Density ($\gram\,\cm^{-3}$) \\
 $T$               & \texttt{T}            & D & \texttt{H5T\_IEEE\_F64LE} & Temperature ($\kelvin$) \\
+$\rho$            & \texttt{rho}          & D & \texttt{H5T\_IEEE\_F64LE} & Density ($\gram\,\cm^{-3}$) \\
 $N^{2}$           & \texttt{N2}           & D & \texttt{H5T\_IEEE\_F64LE} & Brunt-V\"ais\"al\"a frequency squared ($\second^{-2}$) \\
 $\Gamma_{1}$      & \texttt{Gamma\_1}      & D & \texttt{H5T\_IEEE\_F64LE} & $(\partial \ln P/\partial \ln \rho)_{\rm ad}$ \\
 $\nabla_{\rm ad}$  & \texttt{nabla\_ad}      & D & \texttt{H5T\_IEEE\_F64LE} & $(\diff \ln T/\diff \ln P)_{\rm ad}$ \\


### PR DESCRIPTION
According to both MESA and GYRE, the order of columns in ASCII version of GYRE stellar model files should be T then ρ, *not* ρ then T, as is implied by the documentation. e.g. in `src/model/gyre_mesa_file.fpp:426-429` of GYRE 5.2, there's:
````Fortran
      ...
      P = point_data(4,:)
      T = point_data(5,:)
      rho = point_data(6,:)
      nabla = point_data(7,:)
      ...
````
I don't know which other codes produce GYRE stellar models but MESA already does things correctly so this is purely a documentation issue.