### PR TITLE
Update conf.py to fix lost stylesheets with  sphinx_rtd_theme 1.0.0 (should close issue #15)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -83,11 +83,7 @@ html_theme_options = {
 }
 
 # CSS
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-    ],
-}
+html_css_files = ["_static/theme_overrides.css"]  # override wide tables in RTD theme
 
 # Set master doc
 master_doc = 'index'


### PR DESCRIPTION
I was able to reproduce the missing stylesheet issue (#15) locally and the fix [suggested here](https://github.com/readthedocs/sphinx_rtd_theme/issues/1240) worked.