### PR TITLE
Fix call to snap_points in GSM model

### DIFF
--- a/src/model/gyre_gsm_file.fpp
+++ b/src/model/gyre_gsm_file.fpp
@@ -103,7 +103,7 @@ contains
 
     x = r/R_star
 
-    call snap_points(MAX(ml_p%dx_snap, EPSILON(0._WP)), M_r)
+    call snap_points(MAX(ml_p%dx_snap, EPSILON(0._WP)), x, M_r)
   
     ! Calculate dimensionless structure data
 


### PR DESCRIPTION
While testing @VincentVanlaer's newly-added support for GSM models in [`tomso`](https://tomso.readthedocs.io/), I encountered this buggy call to `snap_points` when loading HDF5-format GYRE stellar models. The call is missing the fractional radius argument `x`. This two-character fix worked for me locally.

I think the other calls to `snap_points` are okay. The mass co-ordinate sometimes isn't passed (e.g. for FAMDL and LOSC formats) but `x` always is.