### PR TITLE
Eps grav

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -95,10 +95,10 @@ html_logo = 'gyre-logo.png'
 
 # Set up Extlinks
 extlinks = {
-    'wiki': ('https://en.wikipedia.org/wiki/%s', ''),
-    'netlib': ('https://www.netlib.org/%s', ''),
-    'git': ('https://github.com/%s', ''),
-    'repo': ('https://github.com/rhdtownsend/gyre/blob/{:s}/%s'.format(branch), '')
+    'wiki': ('https://en.wikipedia.org/wiki/%s', None),
+    'netlib': ('https://www.netlib.org/%s', None),
+    'git': ('https://github.com/%s', None),
+    'repo': ('https://github.com/rhdtownsend/gyre/blob/{:s}/%s'.format(branch), None)
 }
 
 # Set site-wide targets

--- a/doc/source/macros.def
+++ b/doc/source/macros.def
@@ -93,6 +93,7 @@ alphapi	\alpha_{\pi}
 alphakat	\alpha_{\kappa,T}
 alphakar	\alpha_{\kappa,\rho}
 alphafrq	\alpha_{\rm frq}
+alphaegv	\alpha_{egv}
 wosc	w_{\rm osc}
 wexp	w_{\rm exp}
 wthm	w_{\rm thm}
@@ -117,6 +118,7 @@ ckapS	c_{\kappa,S}
 ceps	c_{\epsilon}
 cepsad	c_{\epsilon,{\rm ad}}
 cepsS	c_{\epsilon,S}
+cegv	c_{egv}
 frht	f_{\rm rht}
 dfrht	\partial\frht
 elli	\ell_{\rm i}

--- a/doc/source/ref-guide/input-files/osc-params.rst
+++ b/doc/source/ref-guide/input-files/osc-params.rst
@@ -78,6 +78,10 @@ The :nml_g:`osc` namelist group defines oscillation parameters, as follows:
 :nml_n:`alpha_rht` (default :nml_v:`0.`)
   Scaling factor for time-dependent term in radiative heat equation (see the
   :math:`\alpharht` variable in the :ref:`osc-physics-switches` section)
+  
+:nml_n:`alpha_egv` (default :nml_v:`0.`)
+  Scaling factor for the gravitational heating rate :math:`\epsgrav` terms (see the
+  :math:`\alphaegv` variable in the :ref:`osc-physics-switches` section)
 
 :nml_n:`inertia_norm` (default :nml_v:`'BOTH'`)
   Inertia normalization factor; one of

--- a/doc/source/ref-guide/osc-equations/dimless-form.rst
+++ b/doc/source/ref-guide/osc-equations/dimless-form.rst
@@ -73,12 +73,13 @@ The dimensionless oscillation equations are
    \frac{V \nabla}{\frht \crad} y_{6} \\
    %
    x \deriv{y_{6}}{x} &=
-   \left[ \alphahfl \ell(\ell+1) \left( \frac{\nabad}{\nabla} - 1 \right) \crad - V \cepsad \right] y_{1} + \mbox{} \\
+   \left[ \alphahfl \ell(\ell+1) \left( \frac{\nabad}{\nabla} - 1 \right) \crad - V \cepsad - \alphaegv c_{egv} \nabad V \right] y_{1} + \mbox{} \\
    &
-   \left[ V \cepsad - \ell(\ell+1) \crad \left( \alphahfl \frac{\nabad}{\nabla} - \frac{3 + \dcrad}{c_{1}\omegac^{2}} \right) \right] y_{2} + \mbox{} \\
+   \left[ V \cepsad - \ell(\ell+1) \crad \left( \alphahfl \frac{\nabad}{\nabla} - \frac{3 + \dcrad}{c_{1}\omegac^{2}} \right) + \alphaegv c_{egv} \nabad V \right] y_{2} + \mbox{} \\
    &
-   \alphagrv \left[ \ell(\ell+1) \crad \frac{3 + \dcrad}{c_{1}\omegac^{2}} \right] y_{3} +
-   \left[ \cepsS - \alphahfl \frac{\ell(\ell+1)\crad}{\nabla V} + \ii \alphathm \omegac \cthk \right] y_{5} -
+   \alphagrv \left[ \ell(\ell+1) \crad \frac{3 + \dcrad}{c_{1}\omegac^{2}} \right] y_{3} + \mbox{} \\
+   &
+   \left[ \cepsS - \alphahfl \frac{\ell(\ell+1)\crad}{\nabla V} + \ii \alphathm \omegac \cthk + \alphaegv c_{egv} \right] y_{5} -
    \left[ 1 + \ell \right] y_{6}.
    \end{align}
 
@@ -247,6 +248,7 @@ dimensionless oscillation equations are defined as follows:
    \dcthn = \deriv{\ln \cthn}{\ln r} \\
    %
    \cthk = x^{-3} \frac{4\pi r^{3} \cP T \rho}{L} \sqrt{\frac{GM}{R^{3}}}
+   \cegv = x^{-3} \frac{4\pi r^{3} \rho \epsgrav}{L}
    \end{gather}
 
 .. _osc-physics-switches:
@@ -305,3 +307,7 @@ corresponding namelist parameters.
        equation (see :ads_citealp:`unno:1966`). Set to 1 to include this
        term (Unno calls this the Eddington approximation), and to 0 to
        ignore the term
+   * - :math:`\alphaegv`
+     - :nml_n:`alpha_egv`
+     - Scaling factor for the gravitational heating rate terms.
+       Set to 1 to include these terms (default), and to 0 to suppress it.

--- a/src/nad/gyre_nad_eqns.fpp
+++ b/src/nad/gyre_nad_eqns.fpp
@@ -63,7 +63,7 @@ module gyre_nad_eqns
   integer, parameter :: J_DC_THN = 15
   integer, parameter :: J_C_THK = 16
   integer, parameter :: J_C_EPS = 17
-  integer, parameter :: J_C_EGV = 18 ! Added this here and shifted the numbers accordingly
+  integer, parameter :: J_C_EGV = 18
   integer, parameter :: J_KAP_RHO = 19
   integer, parameter :: J_KAP_T = 20
 
@@ -87,7 +87,7 @@ module gyre_nad_eqns
      real(WP)                   :: alpha_kar
      real(WP)                   :: alpha_kat
      real(WP)                   :: alpha_rht
-     real(WP)                   :: alpha_egv ! added this switch here
+     real(WP)                   :: alpha_egv
      integer                    :: conv_scheme
    contains
      private
@@ -135,7 +135,7 @@ contains
     eq%alpha_kar = os_p%alpha_kar
     eq%alpha_kat = os_p%alpha_kat
     eq%alpha_rht = os_p%alpha_rht
-    eq%alpha_egv = os_p%alpha_egv ! added this line for switch
+    eq%alpha_egv = os_p%alpha_egv
        
     select case (os_p%time_factor)
     case ('OSC')
@@ -186,7 +186,7 @@ contains
 
     call check_model(ml, [ &
          I_V_2,I_AS,I_U,I_C_1,I_GAMMA_1,I_NABLA,I_NABLA_AD,I_DELTA, &
-         I_C_LUM,I_C_RAD,I_C_THN,I_C_THK,I_C_EPS,I_C_EGV, & ! added I_C_EGV here
+         I_C_LUM,I_C_RAD,I_C_THN,I_C_THK,I_C_EPS,I_C_EGV, &
          I_KAP_RHO,I_KAP_T])
 
     n_s = SIZE(pt)
@@ -214,7 +214,7 @@ contains
        this%coeff(i,J_C_THN) = ml%coeff(I_C_THN, pt(i))
        this%coeff(i,J_DC_THN) = ml%dcoeff(I_C_THN, pt(i))
        this%coeff(i,J_C_THK) = ml%coeff(I_C_THK, pt(i))
-       this%coeff(i,J_C_EPS) = ml%coeff(I_C_EPS, pt(i)) ! added this line to get the coefficient
+       this%coeff(i,J_C_EPS) = ml%coeff(I_C_EPS, pt(i))
        this%coeff(i, J_C_EGV) = ml%coeff(I_C_EGV, pt(i))
        this%coeff(i,J_KAP_RHO) = ml%coeff(I_KAP_RHO, pt(i))
        this%coeff(i,J_KAP_T) = ml%coeff(I_KAP_T, pt(i))
@@ -300,7 +300,7 @@ contains
          dc_thn => this%coeff(i,J_DC_THN), &
          c_thk => this%coeff(i,J_C_THK), &
          c_eps => this%coeff(i,J_C_EPS), &
-         c_egv => this%coeff(i,J_C_EGV), & ! added this association
+         c_egv => this%coeff(i,J_C_EGV), &
          kap_rho => this%coeff(i,J_KAP_RHO), &
          kap_T => this%coeff(i,J_KAP_T), &
          pt => this%pt(i), &
@@ -316,7 +316,7 @@ contains
          alpha_pi => this%alpha_pi, &
          alpha_kar => this%alpha_kar, &
          alpha_kat => this%alpha_kat, &
-         alpha_egv => this%alpha_egv) ! added egv switch here
+         alpha_egv => this%alpha_egv)
 
       Omega_rot = this%cx%Omega_rot(pt)
       Omega_rot_i = this%cx%Omega_rot(pt_i)
@@ -387,12 +387,12 @@ contains
       xA(5,5) = V*nabla*(4._WP*f_rh - c_kap_S)/f_rh - df_rh - (l_i - 2._WP)
       xA(5,6) = -V*nabla/(c_rad*f_rh)
 
-      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad - alpha_egv*c_egv*nabla_ad*V ! added c_egv here
-      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term + alpha_egv*c_egv*nabla_ad*V ! added c_egv here
+      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad - alpha_egv*c_egv*nabla_ad*V
+      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term + alpha_egv*c_egv*nabla_ad*V
       xA(6,3) = alpha_grv*conv_term
       xA(6,4) = alpha_grv*(0._WP)
       if (x > 0._WP) then
-         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk + alpha_egv*c_egv ! added c_egv here
+         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk + alpha_egv*c_egv
       else
          xA(6,5) = -alpha_hfl*HUGE(0._WP)
       endif

--- a/src/nad/gyre_nad_eqns.fpp
+++ b/src/nad/gyre_nad_eqns.fpp
@@ -63,8 +63,9 @@ module gyre_nad_eqns
   integer, parameter :: J_DC_THN = 15
   integer, parameter :: J_C_THK = 16
   integer, parameter :: J_C_EPS = 17
-  integer, parameter :: J_KAP_RHO = 18
-  integer, parameter :: J_KAP_T = 19
+  integer, parameter :: J_C_EGV = 18 ! Added this here and shifted the numbers accordingly
+  integer, parameter :: J_KAP_RHO = 19
+  integer, parameter :: J_KAP_T = 20
 
   integer, parameter :: J_LAST = J_KAP_T
 
@@ -86,6 +87,7 @@ module gyre_nad_eqns
      real(WP)                   :: alpha_kar
      real(WP)                   :: alpha_kat
      real(WP)                   :: alpha_rht
+     real(WP)                   :: alpha_egv ! added this switch here
      integer                    :: conv_scheme
    contains
      private
@@ -133,6 +135,7 @@ contains
     eq%alpha_kar = os_p%alpha_kar
     eq%alpha_kat = os_p%alpha_kat
     eq%alpha_rht = os_p%alpha_rht
+    eq%alpha_egv = os_p%alpha_egv ! added this line for switch
        
     select case (os_p%time_factor)
     case ('OSC')
@@ -183,7 +186,7 @@ contains
 
     call check_model(ml, [ &
          I_V_2,I_AS,I_U,I_C_1,I_GAMMA_1,I_NABLA,I_NABLA_AD,I_DELTA, &
-         I_C_LUM,I_C_RAD,I_C_THN,I_C_THK,I_C_EPS, &
+         I_C_LUM,I_C_RAD,I_C_THN,I_C_THK,I_C_EPS,I_C_EGV, & ! added I_C_EGV here
          I_KAP_RHO,I_KAP_T])
 
     n_s = SIZE(pt)
@@ -211,7 +214,8 @@ contains
        this%coeff(i,J_C_THN) = ml%coeff(I_C_THN, pt(i))
        this%coeff(i,J_DC_THN) = ml%dcoeff(I_C_THN, pt(i))
        this%coeff(i,J_C_THK) = ml%coeff(I_C_THK, pt(i))
-       this%coeff(i,J_C_EPS) = ml%coeff(I_C_EPS, pt(i))
+       this%coeff(i,J_C_EPS) = ml%coeff(I_C_EPS, pt(i)) ! added this line to get the coefficient
+       this%coeff(i, J_C_EGV) = ml%coeff(I_C_EGV, pt(i))
        this%coeff(i,J_KAP_RHO) = ml%coeff(I_KAP_RHO, pt(i))
        this%coeff(i,J_KAP_T) = ml%coeff(I_KAP_T, pt(i))
 
@@ -296,6 +300,7 @@ contains
          dc_thn => this%coeff(i,J_DC_THN), &
          c_thk => this%coeff(i,J_C_THK), &
          c_eps => this%coeff(i,J_C_EPS), &
+         c_egv => this%coeff(i,J_C_EGV), & ! added this association
          kap_rho => this%coeff(i,J_KAP_RHO), &
          kap_T => this%coeff(i,J_KAP_T), &
          pt => this%pt(i), &
@@ -310,7 +315,8 @@ contains
          alpha_gam => this%alpha_gam, &
          alpha_pi => this%alpha_pi, &
          alpha_kar => this%alpha_kar, &
-         alpha_kat => this%alpha_kat)
+         alpha_kat => this%alpha_kat, &
+         alpha_egv => this%alpha_egv) ! added egv switch here
 
       Omega_rot = this%cx%Omega_rot(pt)
       Omega_rot_i = this%cx%Omega_rot(pt_i)
@@ -381,12 +387,12 @@ contains
       xA(5,5) = V*nabla*(4._WP*f_rh - c_kap_S)/f_rh - df_rh - (l_i - 2._WP)
       xA(5,6) = -V*nabla/(c_rad*f_rh)
 
-      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad
-      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term
+      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad + alpha_egv*c_egv*nabla_ad*V ! added c_egv here
+      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term - alpha_egv*c_egv*nabla_ad*V ! added c_egv here
       xA(6,3) = alpha_grv*conv_term
       xA(6,4) = alpha_grv*(0._WP)
       if (x > 0._WP) then
-         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk
+         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk - alpha_egv*c_egv ! added c_egv here
       else
          xA(6,5) = -alpha_hfl*HUGE(0._WP)
       endif

--- a/src/nad/gyre_nad_eqns.fpp
+++ b/src/nad/gyre_nad_eqns.fpp
@@ -63,9 +63,8 @@ module gyre_nad_eqns
   integer, parameter :: J_DC_THN = 15
   integer, parameter :: J_C_THK = 16
   integer, parameter :: J_C_EPS = 17
-  integer, parameter :: J_C_EGV = 18 ! Added this here and shifted the numbers accordingly
-  integer, parameter :: J_KAP_RHO = 19
-  integer, parameter :: J_KAP_T = 20
+  integer, parameter :: J_KAP_RHO = 18
+  integer, parameter :: J_KAP_T = 19
 
   integer, parameter :: J_LAST = J_KAP_T
 
@@ -87,7 +86,6 @@ module gyre_nad_eqns
      real(WP)                   :: alpha_kar
      real(WP)                   :: alpha_kat
      real(WP)                   :: alpha_rht
-     real(WP)                   :: alpha_egv ! added this switch here
      integer                    :: conv_scheme
    contains
      private
@@ -135,7 +133,6 @@ contains
     eq%alpha_kar = os_p%alpha_kar
     eq%alpha_kat = os_p%alpha_kat
     eq%alpha_rht = os_p%alpha_rht
-    eq%alpha_egv = os_p%alpha_egv ! added this line for switch
        
     select case (os_p%time_factor)
     case ('OSC')
@@ -186,7 +183,7 @@ contains
 
     call check_model(ml, [ &
          I_V_2,I_AS,I_U,I_C_1,I_GAMMA_1,I_NABLA,I_NABLA_AD,I_DELTA, &
-         I_C_LUM,I_C_RAD,I_C_THN,I_C_THK,I_C_EPS,I_C_EGV, & ! added I_C_EGV here
+         I_C_LUM,I_C_RAD,I_C_THN,I_C_THK,I_C_EPS, &
          I_KAP_RHO,I_KAP_T])
 
     n_s = SIZE(pt)
@@ -214,8 +211,7 @@ contains
        this%coeff(i,J_C_THN) = ml%coeff(I_C_THN, pt(i))
        this%coeff(i,J_DC_THN) = ml%dcoeff(I_C_THN, pt(i))
        this%coeff(i,J_C_THK) = ml%coeff(I_C_THK, pt(i))
-       this%coeff(i,J_C_EPS) = ml%coeff(I_C_EPS, pt(i)) ! added this line to get the coefficient
-       this%coeff(i, J_C_EGV) = ml%coeff(I_C_EGV, pt(i))
+       this%coeff(i,J_C_EPS) = ml%coeff(I_C_EPS, pt(i))
        this%coeff(i,J_KAP_RHO) = ml%coeff(I_KAP_RHO, pt(i))
        this%coeff(i,J_KAP_T) = ml%coeff(I_KAP_T, pt(i))
 
@@ -300,7 +296,6 @@ contains
          dc_thn => this%coeff(i,J_DC_THN), &
          c_thk => this%coeff(i,J_C_THK), &
          c_eps => this%coeff(i,J_C_EPS), &
-         c_egv => this%coeff(i,J_C_EGV), & ! added this association
          kap_rho => this%coeff(i,J_KAP_RHO), &
          kap_T => this%coeff(i,J_KAP_T), &
          pt => this%pt(i), &
@@ -315,8 +310,7 @@ contains
          alpha_gam => this%alpha_gam, &
          alpha_pi => this%alpha_pi, &
          alpha_kar => this%alpha_kar, &
-         alpha_kat => this%alpha_kat, &
-         alpha_egv => this%alpha_egv) ! added egv switch here
+         alpha_kat => this%alpha_kat)
 
       Omega_rot = this%cx%Omega_rot(pt)
       Omega_rot_i = this%cx%Omega_rot(pt_i)
@@ -387,12 +381,12 @@ contains
       xA(5,5) = V*nabla*(4._WP*f_rh - c_kap_S)/f_rh - df_rh - (l_i - 2._WP)
       xA(5,6) = -V*nabla/(c_rad*f_rh)
 
-      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad + alpha_egv*c_egv*nabla_ad*V ! added c_egv here
-      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term - alpha_egv*c_egv*nabla_ad*V ! added c_egv here
+      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad
+      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term
       xA(6,3) = alpha_grv*conv_term
       xA(6,4) = alpha_grv*(0._WP)
       if (x > 0._WP) then
-         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk - alpha_egv*c_egv ! added c_egv here
+         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk
       else
          xA(6,5) = -alpha_hfl*HUGE(0._WP)
       endif

--- a/src/nad/gyre_nad_eqns.fpp
+++ b/src/nad/gyre_nad_eqns.fpp
@@ -387,12 +387,12 @@ contains
       xA(5,5) = V*nabla*(4._WP*f_rh - c_kap_S)/f_rh - df_rh - (l_i - 2._WP)
       xA(5,6) = -V*nabla/(c_rad*f_rh)
 
-      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad + alpha_egv*c_egv*nabla_ad*V ! added c_egv here
-      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term - alpha_egv*c_egv*nabla_ad*V ! added c_egv here
+      xA(6,1) = alpha_hfl*lambda*(nabla_ad/nabla - 1._WP)*c_rad - V*c_eps_ad - alpha_egv*c_egv*nabla_ad*V ! added c_egv here
+      xA(6,2) = V*c_eps_ad - lambda*c_rad*alpha_hfl*nabla_ad/nabla + conv_term + alpha_egv*c_egv*nabla_ad*V ! added c_egv here
       xA(6,3) = alpha_grv*conv_term
       xA(6,4) = alpha_grv*(0._WP)
       if (x > 0._WP) then
-         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk - alpha_egv*c_egv ! added c_egv here
+         xA(6,5) = c_eps_S - alpha_hfl*lambda*c_rad/(nabla*V) + alpha_thm*i_omega_c*c_thk + alpha_egv*c_egv ! added c_egv here
       else
          xA(6,5) = -alpha_hfl*HUGE(0._WP)
       endif

--- a/src/par/gyre_osc_par.fpp
+++ b/src/par/gyre_osc_par.fpp
@@ -41,7 +41,7 @@ module gyre_osc_par
      real(WP)                :: alpha_pi = 1._WP
      real(WP)                :: alpha_kar = 1._WP
      real(WP)                :: alpha_kat = 1._WP
-     real(WP)                :: alpha_egv = 1._WP ! added alpha_egv
+     real(WP)                :: alpha_egv = 1._WP
      real(WP)                :: alpha_rht = 0._WP
      real(WP)                :: alpha_trb = 0._WP
      character(64)           :: variables_set = 'GYRE'
@@ -94,7 +94,7 @@ contains
     real(WP)                              :: alpha_kat
     real(WP)                              :: alpha_rht
     real(WP)                              :: alpha_trb
-    real(WP)                              :: alpha_egv ! added alpha_egv
+    real(WP)                              :: alpha_egv
     character(LEN(os_p%variables_set))    :: variables_set
     character(LEN(os_p%inner_bound))      :: inner_bound
     character(LEN(os_p%outer_bound))      :: outer_bound
@@ -114,7 +114,7 @@ contains
     logical                               :: reduce_order
 
     namelist /osc/ x_ref, x_atm, alpha_grv, alpha_thm, alpha_hfl, &
-         alpha_gam, alpha_pi, alpha_kar, alpha_kat, alpha_rht, alpha_trb, alpha_egv, & ! added alpha_egv
+         alpha_gam, alpha_pi, alpha_kar, alpha_kat, alpha_rht, alpha_trb, alpha_egv, &
          inner_bound, outer_bound, outer_bound_cutoff, outer_bound_branch, &
          variables_set, inertia_norm, time_factor, &
          conv_scheme, zeta_scheme, deps_source, deps_file, deps_file_format, &
@@ -157,7 +157,7 @@ contains
        alpha_kat = os_p(i)%alpha_kat
        alpha_rht = os_p(i)%alpha_rht
        alpha_trb = os_p(i)%alpha_trb
-       alpha_egv = os_p(i)%alpha_egv ! added alpha_egv
+       alpha_egv = os_p(i)%alpha_egv
        variables_set = os_p(i)%variables_set
        inner_bound = os_p(i)%inner_bound
        outer_bound = os_p(i)%outer_bound
@@ -193,7 +193,7 @@ contains
        os_p(i)%alpha_kat = alpha_kat
        os_p(i)%alpha_rht = alpha_rht
        os_p(i)%alpha_trb = alpha_trb
-       os_p(i)%alpha_egv = alpha_egv ! added alpha_egv
+       os_p(i)%alpha_egv = alpha_egv
        os_p(i)%variables_set = variables_set
        os_p(i)%inner_bound = inner_bound
        os_p(i)%outer_bound = outer_bound

--- a/src/par/gyre_osc_par.fpp
+++ b/src/par/gyre_osc_par.fpp
@@ -41,9 +41,9 @@ module gyre_osc_par
      real(WP)                :: alpha_pi = 1._WP
      real(WP)                :: alpha_kar = 1._WP
      real(WP)                :: alpha_kat = 1._WP
+     real(WP)                :: alpha_egv = 1._WP ! added alpha_egv
      real(WP)                :: alpha_rht = 0._WP
      real(WP)                :: alpha_trb = 0._WP
-     real(WP)                :: alpha_egv = 0._WP ! added alpha_egv
      character(64)           :: variables_set = 'GYRE'
      character(64)           :: inner_bound = 'REGULAR'
      character(64)           :: outer_bound = 'VACUUM'

--- a/src/par/gyre_osc_par.fpp
+++ b/src/par/gyre_osc_par.fpp
@@ -43,6 +43,7 @@ module gyre_osc_par
      real(WP)                :: alpha_kat = 1._WP
      real(WP)                :: alpha_rht = 0._WP
      real(WP)                :: alpha_trb = 0._WP
+     real(WP)                :: alpha_egv = 0._WP ! added alpha_egv
      character(64)           :: variables_set = 'GYRE'
      character(64)           :: inner_bound = 'REGULAR'
      character(64)           :: outer_bound = 'VACUUM'
@@ -93,6 +94,7 @@ contains
     real(WP)                              :: alpha_kat
     real(WP)                              :: alpha_rht
     real(WP)                              :: alpha_trb
+    real(WP)                              :: alpha_egv ! added alpha_egv
     character(LEN(os_p%variables_set))    :: variables_set
     character(LEN(os_p%inner_bound))      :: inner_bound
     character(LEN(os_p%outer_bound))      :: outer_bound
@@ -112,7 +114,7 @@ contains
     logical                               :: reduce_order
 
     namelist /osc/ x_ref, x_atm, alpha_grv, alpha_thm, alpha_hfl, &
-         alpha_gam, alpha_pi, alpha_kar, alpha_kat, alpha_rht, alpha_trb, &
+         alpha_gam, alpha_pi, alpha_kar, alpha_kat, alpha_rht, alpha_trb, alpha_egv, & ! added alpha_egv
          inner_bound, outer_bound, outer_bound_cutoff, outer_bound_branch, &
          variables_set, inertia_norm, time_factor, &
          conv_scheme, zeta_scheme, deps_source, deps_file, deps_file_format, &
@@ -155,6 +157,7 @@ contains
        alpha_kat = os_p(i)%alpha_kat
        alpha_rht = os_p(i)%alpha_rht
        alpha_trb = os_p(i)%alpha_trb
+       alpha_egv = os_p(i)%alpha_egv ! added alpha_egv
        variables_set = os_p(i)%variables_set
        inner_bound = os_p(i)%inner_bound
        outer_bound = os_p(i)%outer_bound
@@ -190,6 +193,7 @@ contains
        os_p(i)%alpha_kat = alpha_kat
        os_p(i)%alpha_rht = alpha_rht
        os_p(i)%alpha_trb = alpha_trb
+       os_p(i)%alpha_egv = alpha_egv ! added alpha_egv
        os_p(i)%variables_set = variables_set
        os_p(i)%inner_bound = inner_bound
        os_p(i)%outer_bound = outer_bound

--- a/src/par/gyre_osc_par.fpp
+++ b/src/par/gyre_osc_par.fpp
@@ -43,7 +43,6 @@ module gyre_osc_par
      real(WP)                :: alpha_kat = 1._WP
      real(WP)                :: alpha_rht = 0._WP
      real(WP)                :: alpha_trb = 0._WP
-     real(WP)                :: alpha_egv = 0._WP ! added alpha_egv
      character(64)           :: variables_set = 'GYRE'
      character(64)           :: inner_bound = 'REGULAR'
      character(64)           :: outer_bound = 'VACUUM'
@@ -94,7 +93,6 @@ contains
     real(WP)                              :: alpha_kat
     real(WP)                              :: alpha_rht
     real(WP)                              :: alpha_trb
-    real(WP)                              :: alpha_egv ! added alpha_egv
     character(LEN(os_p%variables_set))    :: variables_set
     character(LEN(os_p%inner_bound))      :: inner_bound
     character(LEN(os_p%outer_bound))      :: outer_bound
@@ -114,7 +112,7 @@ contains
     logical                               :: reduce_order
 
     namelist /osc/ x_ref, x_atm, alpha_grv, alpha_thm, alpha_hfl, &
-         alpha_gam, alpha_pi, alpha_kar, alpha_kat, alpha_rht, alpha_trb, alpha_egv, & ! added alpha_egv
+         alpha_gam, alpha_pi, alpha_kar, alpha_kat, alpha_rht, alpha_trb, &
          inner_bound, outer_bound, outer_bound_cutoff, outer_bound_branch, &
          variables_set, inertia_norm, time_factor, &
          conv_scheme, zeta_scheme, deps_source, deps_file, deps_file_format, &
@@ -157,7 +155,6 @@ contains
        alpha_kat = os_p(i)%alpha_kat
        alpha_rht = os_p(i)%alpha_rht
        alpha_trb = os_p(i)%alpha_trb
-       alpha_egv = os_p(i)%alpha_egv ! added alpha_egv
        variables_set = os_p(i)%variables_set
        inner_bound = os_p(i)%inner_bound
        outer_bound = os_p(i)%outer_bound
@@ -193,7 +190,6 @@ contains
        os_p(i)%alpha_kat = alpha_kat
        os_p(i)%alpha_rht = alpha_rht
        os_p(i)%alpha_trb = alpha_trb
-       os_p(i)%alpha_egv = alpha_egv ! added alpha_egv
        os_p(i)%variables_set = variables_set
        os_p(i)%inner_bound = inner_bound
        os_p(i)%outer_bound = outer_bound


### PR DESCRIPTION
Added code to include eps-grav in the non-adiabatic equations, added a physics switch `alpha_egv` for the new contribution, and updated the documentation to include the new terms and physic switch.

In `gyre_nad_eqns.fpp`, added code to read in `c_egv` and added it to the equations. In `gyre_osc_par.fpp`, added the new physics switch and set it's default value to 1.

Updated the `osc-params.rst` and `dimless-form.rst` doc pages for the new term.

In the Sphinx configuration file `conf.py`, I changed the empty strings to `None` to address warning messages regarding changes to version 6.0.0 of Sphinx. 