### PR TITLE
Fix upsilon

### DIFF
--- a/doc/source/ref-guide/osc-equations/dimless-form.rst
+++ b/doc/source/ref-guide/osc-equations/dimless-form.rst
@@ -42,13 +42,13 @@ The dimensionless oscillation equations are
    \left( \frac{V}{\Gammi} - 1 - \ell \right) y_{1} +
    \left( \frac{\ell(\ell+1)}{c_{1} \omegac^{2}} - \alphagam \frac{V}{\Gammi} \right) y_{2} +
    \alphagrv \frac{\ell(\ell+1)}{c_{1} \omegac^{2}} y_{3} +
-   \delta \, y_{5}, \\
+   \upsT \, y_{5}, \\
    %
    x \deriv{y_{2}}{x} &=
    \left( c_{1} \omegac^{2} - \fpigam \As \right) y_{1} +
    \left( 3 - U + \As - \ell \right) y_{2} -
    \alphagrv y_{4} +
-   \delta \, y_{5}, \\
+   \upsT \, y_{5}, \\
    %
    x \deriv{y_{3}}{x} &= 
    \alphagrv \left( 3 - U - \ell \right) y_{3} +
@@ -59,7 +59,7 @@ The dimensionless oscillation equations are
    \alphagrv \frac{V}{\Gammi} U y_{2} +
    \alphagrv \ell(\ell+1) y_{3} -
    \alphagrv (U + \ell - 2) y_{4}
-   - \alphagrv \delta \, U y_{5}, \\
+   - \alphagrv \upsT \, U y_{5}, \\
    %
    x \deriv{y_{5}}{x} &= 
    \frac{V}{\frht} \left[ \nabad (U - c_{1}\omegac^{2}) - 4 (\nabad - \nabla) + \ckapad V \nabla + \cdif \right] y_{1} + \mbox{} \\

--- a/src/mode/gyre_wave.fpp
+++ b/src/mode/gyre_wave.fpp
@@ -922,7 +922,7 @@ contains
     complex(WP) :: lag_P
     complex(WP) :: lag_S
     real(WP)    :: Gamma_1
-    real(WP)    :: delta
+    real(WP)    :: ups_T
 
     ! Evaluate the Lagrangian density perturbation, in units of
     ! rho. This expression implements eqn. (13.83) of [Unno:1989]
@@ -938,9 +938,9 @@ contains
 
       if (lag_S /= 0._WP) then
 
-         delta = ml%coeff(I_DELTA, pt)
+         ups_T = ml%coeff(I_UPS_T, pt)
 
-         lag_rho = lag_P/Gamma_1 - delta*lag_S
+         lag_rho = lag_P/Gamma_1 - ups_T*lag_S
 
       else
 

--- a/src/model/gyre_b3_file.fpp
+++ b/src/model/gyre_b3_file.fpp
@@ -79,7 +79,7 @@ contains
     real(WP), allocatable       :: eps_T(:)
     real(WP), allocatable       :: Gamma_1(:)
     real(WP), allocatable       :: nabla_ad(:)
-    real(WP), allocatable       :: delta(:)
+    real(WP), allocatable       :: ups_T(:)
     real(WP), allocatable       :: x(:)
     real(WP), allocatable       :: V_2(:)
     real(WP), allocatable       :: As(:)
@@ -156,8 +156,8 @@ contains
     eps = eps*1.E4_WP
     
     Gamma_1 = chi_rho*c_p/c_V
-    delta = chi_T/chi_rho
-    nabla_ad = p*delta/(rho*T*c_p)
+    ups_T = chi_T/chi_rho
+    nabla_ad = p*ups_T/(rho*T*c_p)
 
     ! Snap grid points
 
@@ -208,7 +208,7 @@ contains
     call em%define(I_C_1, c_1)
 
     call em%define(I_GAMMA_1, Gamma_1)
-    call em%define(I_DELTA, delta)
+    call em%define(I_UPS_T, ups_T)
     call em%define(I_NABLA_AD, nabla_ad)
     call em%define(I_NABLA, nabla)
     call em%define(I_BETA_RAD, beta_rad)

--- a/src/model/gyre_fgong_file.fpp
+++ b/src/model/gyre_fgong_file.fpp
@@ -71,7 +71,7 @@ contains
     real(WP), allocatable       :: T(:) 
     real(WP), allocatable       :: Gamma_1(:)
     real(WP), allocatable       :: nabla_ad(:)
-    real(WP), allocatable       :: delta(:)
+    real(WP), allocatable       :: ups_T(:)
     real(WP), allocatable       :: beta_rad(:)
     real(WP), allocatable       :: V_2(:)
     real(WP), allocatable       :: As(:)
@@ -154,7 +154,7 @@ contains
 
     Gamma_1 = var(10,:)
     nabla_ad = var(11,:)
-    delta = var(12,:)
+    ups_T = var(12,:)
 
     As = var(15,:)
 
@@ -194,7 +194,7 @@ contains
     call em%define(I_C_1, c_1)
 
     call em%define(I_GAMMA_1, Gamma_1)
-    call em%define(I_DELTA, delta)
+    call em%define(I_UPS_T, ups_T)
     call em%define(I_NABLA_AD, nabla_ad)
 
     call em%define(I_BETA_RAD, beta_rad)

--- a/src/model/gyre_gsm_file.fpp
+++ b/src/model/gyre_gsm_file.fpp
@@ -66,7 +66,7 @@ contains
     real(WP), allocatable       :: N2(:)
     real(WP), allocatable       :: Gamma_1(:)
     real(WP), allocatable       :: nabla_ad(:)
-    real(WP), allocatable       :: delta(:)
+    real(WP), allocatable       :: ups_T(:)
     real(WP), allocatable       :: nabla(:)
     real(WP), allocatable       :: kap(:)
     real(WP), allocatable       :: kap_rho(:)
@@ -97,7 +97,7 @@ contains
     ! Read data from the GSM-format file
 
     call read_gsm_data(ml_p%file, M_star, R_star, L_star, r, M_r, L_r, P, rho, T, &
-                       N2, Gamma_1, nabla_ad, delta, nabla,  &
+                       N2, Gamma_1, nabla_ad, ups_T, nabla,  &
                        kap, kap_rho, kap_T, eps, eps_eps_rho, eps_eps_T, eps_grav, &
                        Omega_rot)
 
@@ -133,7 +133,7 @@ contains
 
     beta_rad = A_RADIATION*T**4/(3._WP*P)
 
-    c_P = P*delta/(rho*T*nabla_ad)
+    c_P = P*ups_T/(rho*T*nabla_ad)
 
     c_rad = 16._WP*PI*A_RADIATION*C_LIGHT*T**4*R_star*nabla*V_2/(3._WP*kap*rho*L_star)
     c_thn = c_P*sqrt(G_GRAVITY*M_star/R_star**3)/(A_RADIATION*C_LIGHT*kap*T**3)
@@ -164,7 +164,7 @@ contains
     call em%define(I_C_1, c_1)
 
     call em%define(I_GAMMA_1, Gamma_1)
-    call em%define(I_DELTA, delta)
+    call em%define(I_UPS_T, ups_T)
     call em%define(I_NABLA_AD, nabla_ad)
     call em%define(I_NABLA, nabla)
     call em%define(I_BETA_RAD, beta_rad)
@@ -203,7 +203,7 @@ contains
   !****
 
   subroutine read_gsm_data (file, M_star, R_star, L_star, r, M_r, L_r, P, rho, T, &
-                            N2, Gamma_1, nabla_ad, delta, nabla,  &
+                            N2, Gamma_1, nabla_ad, ups_T, nabla,  &
                             kap, kap_rho, kap_T, eps, eps_eps_rho, eps_eps_T, eps_grav, &
                             Omega_rot)
 
@@ -220,7 +220,7 @@ contains
     real(WP), allocatable, intent(out) :: N2(:)
     real(WP), allocatable, intent(out) :: Gamma_1(:)
     real(WP), allocatable, intent(out) :: nabla_ad(:)
-    real(WP), allocatable, intent(out) :: delta(:)
+    real(WP), allocatable, intent(out) :: ups_T(:)
     real(WP), allocatable, intent(out) :: nabla(:)
     real(WP), allocatable, intent(out) :: kap(:)
     real(WP), allocatable, intent(out) :: kap_rho(:)
@@ -303,7 +303,7 @@ contains
       call read_dset_alloc(hg, 'N2', N2)
       call read_dset_alloc(hg, 'Gamma_1', Gamma_1)
       call read_dset_alloc(hg, 'nabla_ad', nabla_ad)
-      call read_dset_alloc(hg, 'delta', delta)
+      call read_dset_alloc(hg, 'delta', ups_T)
       call read_dset_alloc(hg, 'nabla', nabla)
       call read_dset_alloc(hg, 'kappa', kap)
       call read_dset_alloc(hg, 'kappa_rho', kap_rho)
@@ -339,7 +339,7 @@ contains
       call read_dset_alloc(hg, 'N2', N2)
       call read_dset_alloc(hg, 'Gamma_1', Gamma_1)
       call read_dset_alloc(hg, 'nabla_ad', nabla_ad)
-      call read_dset_alloc(hg, 'delta', delta)
+      call read_dset_alloc(hg, 'delta', ups_T)
       call read_dset_alloc(hg, 'nabla', nabla)
       call read_dset_alloc(hg, 'kap', kap)
       call read_dset_alloc(hg, 'kap_rho', kap_kap_rho)
@@ -376,7 +376,7 @@ contains
       call read_dset_alloc(hg, 'N2', N2)
       call read_dset_alloc(hg, 'Gamma_1', Gamma_1)
       call read_dset_alloc(hg, 'nabla_ad', nabla_ad)
-      call read_dset_alloc(hg, 'delta', delta)
+      call read_dset_alloc(hg, 'delta', ups_T)
       call read_dset_alloc(hg, 'nabla', nabla)
       call read_dset_alloc(hg, 'kap', kap)
       call read_dset_alloc(hg, 'kap_kap_rho', kap_kap_rho)
@@ -413,7 +413,7 @@ contains
       call read_dset_alloc(hg, 'N2', N2)
       call read_dset_alloc(hg, 'Gamma_1', Gamma_1)
       call read_dset_alloc(hg, 'nabla_ad', nabla_ad)
-      call read_dset_alloc(hg, 'delta', delta)
+      call read_dset_alloc(hg, 'delta', ups_T)
       call read_dset_alloc(hg, 'nabla', nabla)
       call read_dset_alloc(hg, 'kap', kap)
       call read_dset_alloc(hg, 'kap_kap_rho', kap_kap_rho)

--- a/src/model/gyre_hom_model.fpp
+++ b/src/model/gyre_hom_model.fpp
@@ -153,7 +153,7 @@ contains
        coeff = 1._WP
     case (I_GAMMA_1)
        coeff = this%Gamma_1
-    case (I_DELTA)
+    case (I_UPS_T)
        coeff = 1._WP
     case (I_NABLA_AD)
        coeff = 0.4_WP
@@ -234,7 +234,7 @@ contains
        dcoeff = 0._WP
     case (I_GAMMA_1)
        dcoeff = 0._WP
-    case (I_DELTA)
+    case (I_UPS_T)
        dcoeff = 0._WP
     case (I_NABLA_AD)
        dcoeff = 0._WP
@@ -297,7 +297,7 @@ contains
     ! Return the definition status of the i'th coefficient
 
     select case (i)
-    case (I_V_2, I_AS, I_U, I_C_1, I_GAMMA_1, I_DELTA, I_NABLA_AD, I_OMEGA_ROT)
+    case (I_V_2, I_AS, I_U, I_C_1, I_GAMMA_1, I_UPS_T, I_NABLA_AD, I_OMEGA_ROT)
        is_defined = .TRUE.
     case default
        is_defined = .FALSE.

--- a/src/model/gyre_mesa_file.fpp
+++ b/src/model/gyre_mesa_file.fpp
@@ -162,7 +162,7 @@ contains
     real(WP), allocatable       :: N2(:)
     real(WP), allocatable       :: Gamma_1(:)
     real(WP), allocatable       :: nabla_ad(:)
-    real(WP), allocatable       :: delta(:)
+    real(WP), allocatable       :: ups_T(:)
     real(WP), allocatable       :: nabla(:)
     real(WP), allocatable       :: eps(:)
     real(WP), allocatable       :: eps_rho(:)
@@ -237,7 +237,7 @@ contains
 
     beta_rad = A_RADIATION*T**4/(3._WP*P)
 
-    c_P = P*delta/(rho*T*nabla_ad)
+    c_P = P*ups_T/(rho*T*nabla_ad)
 
     c_rad = 16._WP*PI*A_RADIATION*C_LIGHT*T**4*R_star*nabla*V_2/(3._WP*kap*rho*L_star)
     c_thn = c_P*sqrt(G_GRAVITY*M_star/R_star**3)/(A_RADIATION*C_LIGHT*kap*T**3)
@@ -270,7 +270,7 @@ contains
     call em%define(I_C_1, c_1)
 
     call em%define(I_GAMMA_1, Gamma_1)
-    call em%define(I_DELTA, delta)
+    call em%define(I_UPS_T, ups_T)
     call em%define(I_NABLA_AD, nabla_ad)
     call em%define(I_NABLA, nabla)
     call em%define(I_BETA_RAD, beta_rad)
@@ -317,7 +317,7 @@ contains
       nabla = point_data(7,:)
       N2 = point_data(8,:)
       Gamma_1 = point_data(12,:)*point_data(10,:)/point_data(9,:)
-      delta = point_data(11,:)/point_data(12,:)
+      ups_T = point_data(11,:)/point_data(12,:)
       kap = point_data(13,:)
       kap_T = point_data(14,:)
       kap_rho = point_data(15,:)
@@ -325,7 +325,7 @@ contains
       eps_eps_T = point_data(17,:)
       eps_eps_rho = point_data(18,:)
 
-      nabla_ad = p*delta/(rho*T*point_data(10,:))
+      nabla_ad = p*ups_T/(rho*T*point_data(10,:))
 
       allocate(Omega_rot(n))
       Omega_rot = 0._WP
@@ -378,7 +378,7 @@ contains
       N2 = point_data(8,:)
       Gamma_1 = point_data(9,:)
       nabla_ad = point_data(10,:)
-      delta = point_data(11,:)
+      ups_T = point_data(11,:)
       kap = point_data(12,:)
       kap_T = point_data(13,:)
       kap_rho = point_data(14,:)
@@ -427,7 +427,7 @@ contains
       N2 = point_data(8,:)
       Gamma_1 = point_data(9,:)
       nabla_ad = point_data(10,:)
-      delta = point_data(11,:)
+      ups_T = point_data(11,:)
       kap = point_data(12,:)
       kap_kap_T = point_data(13,:)
       kap_kap_rho = point_data(14,:)
@@ -479,7 +479,7 @@ contains
       N2 = point_data(8,:)
       Gamma_1 = point_data(9,:)
       nabla_ad = point_data(10,:)
-      delta = point_data(11,:)
+      ups_T = point_data(11,:)
       kap = point_data(12,:)
       kap_kap_T = point_data(13,:)
       kap_kap_rho = point_data(14,:)

--- a/src/model/gyre_model.fpp
+++ b/src/model/gyre_model.fpp
@@ -36,7 +36,7 @@ module gyre_model
   integer, parameter :: I_U = 3
   integer, parameter :: I_C_1 = 4
   integer, parameter :: I_GAMMA_1 = 5
-  integer, parameter :: I_DELTA = 6
+  integer, parameter :: I_UPS_T = 6
   integer, parameter :: I_NABLA_AD = 7
   integer, parameter :: I_NABLA = 8
   integer, parameter :: I_BETA_RAD = 9
@@ -144,7 +144,7 @@ module gyre_model
   public :: I_U
   public :: I_C_1
   public :: I_GAMMA_1
-  public :: I_DELTA
+  public :: I_UPS_T
   public :: I_NABLA_AD
   public :: I_NABLA
   public :: I_BETA_RAD

--- a/src/model/gyre_osc_file.fpp
+++ b/src/model/gyre_osc_file.fpp
@@ -74,7 +74,7 @@ contains
     real(WP), allocatable       :: T(:) 
     real(WP), allocatable       :: Gamma_1(:)
     real(WP), allocatable       :: nabla_ad(:)
-    real(WP), allocatable       :: delta(:)
+    real(WP), allocatable       :: ups_T(:)
     real(WP), allocatable       :: As(:)
     real(WP), allocatable       :: nabla(:)
     real(WP), allocatable       :: kap(:)
@@ -167,7 +167,7 @@ contains
 
     Gamma_1 = point_data(10,:)
     nabla_ad = point_data(11,:)
-    delta = point_data(12,:)
+    ups_T = point_data(12,:)
 
     As = point_data(15,:)
 
@@ -210,7 +210,7 @@ contains
 
     beta_rad = A_RADIATION*T**4/(3._WP*P)
 
-    c_P = P*delta/(rho*T*nabla_ad)
+    c_P = P*ups_T/(rho*T*nabla_ad)
 
     c_rad = 16._WP*PI*A_RADIATION*C_LIGHT*T**4*R_star*nabla*V_2/(3._WP*kap*rho*L_star)
     c_thn = c_P*sqrt(G_GRAVITY*M_star/R_star**3)/(A_RADIATION*C_LIGHT*kap*T**3)
@@ -240,7 +240,7 @@ contains
     call em%define(I_C_1, c_1)
 
     call em%define(I_GAMMA_1, Gamma_1)
-    call em%define(I_DELTA, delta)
+    call em%define(I_UPS_T, ups_T)
     call em%define(I_NABLA_AD, nabla_ad)
     call em%define(I_NABLA, nabla)
     call em%define(I_BETA_RAD, beta_rad)

--- a/src/model/gyre_poly_model.fpp
+++ b/src/model/gyre_poly_model.fpp
@@ -249,7 +249,7 @@ contains
        coeff = this%coeff_c_1_(pt)
     case (I_GAMMA_1)
        coeff = this%Gamma_1
-    case (I_DELTA)
+    case (I_UPS_T)
        coeff = 1._WP
     case (I_NABLA_AD)
        coeff = 0.4_WP
@@ -411,7 +411,7 @@ contains
        dcoeff = this%dcoeff_c_1_(pt)
     case (I_GAMMA_1)
        dcoeff = 0._WP
-    case (I_DELTA)
+    case (I_UPS_T)
        dcoeff = 0._WP
     case (I_NABLA_AD)
        dcoeff = 0._WP
@@ -577,7 +577,7 @@ contains
     ! Return the definition status of the i'th coefficient
 
     select case (i)
-    case (I_V_2, I_AS, I_U, I_C_1, I_GAMMA_1, I_DELTA, I_NABLA_AD, I_OMEGA_ROT)
+    case (I_V_2, I_AS, I_U, I_C_1, I_GAMMA_1, I_UPS_T, I_NABLA_AD, I_OMEGA_ROT)
        is_defined = .TRUE.
     case default
        is_defined = .FALSE.

--- a/src/model/gyre_wdec_file.fpp
+++ b/src/model/gyre_wdec_file.fpp
@@ -67,7 +67,7 @@ contains
     real(WP), allocatable       :: T(:) 
     real(WP), allocatable       :: Gamma_1(:)
     real(WP), allocatable       :: nabla_ad(:)
-    real(WP), allocatable       :: delta(:)
+    real(WP), allocatable       :: ups_T(:)
     real(WP), allocatable       :: nabla(:)
     real(WP), allocatable       :: B(:)
     real(WP), allocatable       :: kap(:)
@@ -140,7 +140,7 @@ contains
 
     Gamma_1 = point_data(9,:)/(1._WP - point_data(10,:)*point_data(16,:))
     nabla_ad = point_data(16,:)
-    delta = point_data(10,:)/point_data(9,:)
+    ups_T = point_data(10,:)/point_data(9,:)
 
     nabla = point_data(15,:)
     B = point_data(19,:)
@@ -178,11 +178,11 @@ contains
        c_lum = 4._WP*PI*rho(1)*eps(1)*R_star**3/L_star
     end where
 
-    As = V_2*x**2*delta*(nabla_ad - nabla + B)
+    As = V_2*x**2*ups_T*(nabla_ad - nabla + B)
 
     beta_rad = A_RADIATION*T**4/(3._WP*P)
 
-    c_P = P*delta/(rho*T*nabla_ad)
+    c_P = P*ups_T/(rho*T*nabla_ad)
 
     c_rad = 16._WP*PI*A_RADIATION*C_LIGHT*T**4*R_star*nabla*V_2/(3._WP*kap*rho*L_star)
     c_thn = c_P*sqrt(G_GRAVITY*M_star/R_star**3)/(A_RADIATION*C_LIGHT*kap*T**3)
@@ -203,7 +203,7 @@ contains
     call em%define(I_C_1, c_1)
 
     call em%define(I_GAMMA_1, Gamma_1)
-    call em%define(I_DELTA, delta)
+    call em%define(I_UPS_T, ups_T)
     call em%define(I_NABLA_AD, nabla_ad)
     call em%define(I_NABLA, nabla)
     call em%define(I_BETA_RAD, beta_rad)

--- a/src/nad/gyre_nad_bound.fpp
+++ b/src/nad/gyre_nad_bound.fpp
@@ -60,9 +60,9 @@ module gyre_nad_bound
   integer, parameter :: J_GAMMA_1 = 5
   integer, parameter :: J_NABLA_AD = 6
   integer, parameter :: J_C_THN = 7
-  integer, parameter :: J_DELTA = 8
+  integer, parameter :: J_UPS_T = 8
 
-  integer, parameter :: J_LAST = J_DELTA
+  integer, parameter :: J_LAST = J_UPS_T
 
   ! Derived-type definitions
 

--- a/src/nad/gyre_nad_eqns.fpp
+++ b/src/nad/gyre_nad_eqns.fpp
@@ -51,7 +51,7 @@ module gyre_nad_eqns
   integer, parameter :: J_U = 3
   integer, parameter :: J_C_1 = 4
   integer, parameter :: J_GAMMA_1 = 5
-  integer, parameter :: J_DELTA = 6
+  integer, parameter :: J_UPS_T = 6
   integer, parameter :: J_NABLA_AD = 7
   integer, parameter :: J_DNABLA_AD = 8
   integer, parameter :: J_NABLA = 9
@@ -185,7 +185,7 @@ contains
     ml => this%cx%model()
 
     call check_model(ml, [ &
-         I_V_2,I_AS,I_U,I_C_1,I_GAMMA_1,I_NABLA,I_NABLA_AD,I_DELTA, &
+         I_V_2,I_AS,I_U,I_C_1,I_GAMMA_1,I_NABLA,I_NABLA_AD,I_UPS_T, &
          I_C_LUM,I_C_RAD,I_C_THN,I_C_THK,I_C_EPS,I_C_EGV, &
          I_KAP_RHO,I_KAP_T])
 
@@ -206,7 +206,7 @@ contains
        this%coeff(i,J_NABLA_AD) = ml%coeff(I_NABLA_AD, pt(i))
        this%coeff(i,J_DNABLA_AD) = ml%dcoeff(I_NABLA_AD, pt(i))
        this%coeff(i,J_NABLA) = ml%coeff(I_NABLA, pt(i))
-       this%coeff(i,J_DELTA) = ml%coeff(I_DELTA, pt(i))
+       this%coeff(i,J_UPS_T) = ml%coeff(I_UPS_T, pt(i))
        this%coeff(i,J_C_LUM) = ml%coeff(I_C_LUM, pt(i))
        this%coeff(i,J_DC_LUM) = ml%dcoeff(I_C_LUM, pt(i))
        this%coeff(i,J_C_RAD) = ml%coeff(I_C_RAD, pt(i))
@@ -291,7 +291,7 @@ contains
          nabla_ad => this%coeff(i,J_NABLA_AD), &
          dnabla_ad => this%coeff(i,J_DNABLA_AD), &
          nabla => this%coeff(i,J_NABLA), &
-         delta => this%coeff(i,J_DELTA), &
+         ups_T => this%coeff(i,J_UPS_T), &
          c_lum => this%coeff(i,J_C_LUM), &
          dc_lum => this%coeff(i,J_DC_LUM), &
          c_rad => this%coeff(i,J_C_RAD), &
@@ -343,10 +343,10 @@ contains
       eps_T = this%cx%eps_T(st, pt)
 
       c_eps_ad = c_eps*(nabla_ad*eps_T + eps_rho/Gamma_1)
-      c_eps_S = c_eps*(eps_T - delta*eps_rho)
+      c_eps_S = c_eps*(eps_T - ups_T*eps_rho)
 
       c_kap_ad = nabla_ad*alpha_kat*kap_T + alpha_kar*kap_rho/Gamma_1
-      c_kap_S = alpha_kat*kap_T - delta*alpha_kar*kap_rho
+      c_kap_S = alpha_kat*kap_T - ups_T*alpha_kar*kap_rho
       
       c_dif = -4._WP*nabla_ad*V*nabla + nabla_ad*(dnabla_ad + V)
 
@@ -356,14 +356,14 @@ contains
       xA(1,2) = lambda/(c_1*alpha_omg*omega_c**2) - V/Gamma_1*alpha_gam
       xA(1,3) = alpha_grv*(lambda/(c_1*alpha_omg*omega_c**2))
       xA(1,4) = alpha_grv*(0._WP)
-      xA(1,5) = delta
+      xA(1,5) = ups_T
       xA(1,6) = 0._WP
 
       xA(2,1) = c_1*alpha_omg*omega_c**2 - As*MERGE(MERGE(alpha_pi, alpha_gam, x<x_atm), 1._WP, As > 0._WP)
       xA(2,2) = As - U + 3._WP - l_i
       xA(2,3) = alpha_grv*(0._WP)
       xA(2,4) = alpha_grv*(-1._WP)
-      xA(2,5) = delta
+      xA(2,5) = ups_T
       xA(2,6) = 0._WP
 
       xA(3,1) = alpha_grv*(0._WP)
@@ -377,7 +377,7 @@ contains
       xA(4,2) = alpha_grv*(U*V/Gamma_1)
       xA(4,3) = alpha_grv*(lambda)
       xA(4,4) = alpha_grv*(-U - l_i + 2._WP)
-      xA(4,5) = alpha_grv*(-U*delta)
+      xA(4,5) = alpha_grv*(-U*ups_T)
       xA(4,6) = alpha_grv*(0._WP)
 
       xA(5,1) = V*(nabla_ad*(U - c_1*alpha_omg*omega_c**2) - 4._WP*(nabla_ad - nabla) + c_kap_ad*V*nabla + c_dif)/f_rh

--- a/src/output/gyre_detail.fpp
+++ b/src/output/gyre_detail.fpp
@@ -482,7 +482,7 @@ contains
     $WRITE_POINTS(nabla,ml%coeff(I_NABLA, gr%pt(j)))
     $WRITE_POINTS(nabla_ad,ml%coeff(I_NABLA_AD, gr%pt(j)))
     $WRITE_POINTS(dnabla_ad,ml%dcoeff(I_NABLA_AD, gr%pt(j)))
-    $WRITE_POINTS(delta,ml%coeff(I_DELTA, gr%pt(j)))
+    $WRITE_POINTS(upsilon_T,ml%coeff(I_UPS_T, gr%pt(j)))
     $WRITE_POINTS(c_lum,ml%coeff(I_C_LUM, gr%pt(j)))
     $WRITE_POINTS(c_rad,ml%coeff(I_C_RAD, gr%pt(j)))
     $WRITE_POINTS(c_thn,ml%coeff(I_C_THN, gr%pt(j)))


### PR DESCRIPTION
Changed the variable name for `delta` (the ratio of compressibilities) to `ups_T`, and renamed the corresponding index variable `I_DELTA` to `I_UPS_T`. The documentation was also updated to be consistent with the use of `upsilon_T`.

As a result, this fixes the bug where putting 'upsilon_T' in for namelist output parameter `detail_item_list` would return an error (as the code was looking for `delta` despite what the documentation suggested)