### PR TITLE
trailing white spaces and tabs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The GYRE Stellar Oscillation Code
 
 Overview
 ========
-	    
+
 GYRE is a *stellar oscillation code*. Given an input stellar model,
 GYRE calculates the eigenfrequencies and eigenfunctions for the normal
 oscillation modes of the model. These data can be put to a variety of

--- a/docs/source/appendices/comp-ptrope.rst
+++ b/docs/source/appendices/comp-ptrope.rst
@@ -23,7 +23,5 @@ index :math:`n`.  This appendix lays out the mathematical formalism\
 .. rubric:: Footnotes
 
 .. [#formalism] The formalism here is based on `Mixed polytrope with density
-		discontinuities` (Christensen-Dalsgaard, 2015, unpublished),
-		with extensions to allow for constant-density regions.
-   
-  
+    discontinuities` (Christensen-Dalsgaard, 2015, unpublished),
+    with extensions to allow for constant-density regions.

--- a/docs/source/appendices/support-tools/build-poly.rst
+++ b/docs/source/appendices/support-tools/build-poly.rst
@@ -14,7 +14,7 @@ Synopsis
 
 Description
 -----------
-	     
+
 The :program:`build_poly` tool constructs a :ref:`composite polytrope
 <comp-ptrope>`, and writes it to a file in the :ref:`POLY
 <poly-file-format>` format.
@@ -50,7 +50,7 @@ Options
 .. option:: -d, --dz=DZ
 
    Grid spacing in polytropic coordinate.
-   
+
 .. option:: -t, --toler=TOLER
 
    Tolerance of Lane-Emden equation solver.
@@ -61,7 +61,7 @@ Examples
 To build a simple (complete) polytrope with :math:`\npoly=3`, run :program:`build_poly` as follows:
 
 .. code-block:: console
-                         
+
    $ $GYRE_DIR/bin/build_poly --n_poly=3 --dz=0.01 poly.simple.h5
 
 This model, written to the file :file:`poly.simple.h5`, is visualized in the figure below.
@@ -82,7 +82,7 @@ To build a composite polytrope, comprising two regions (inner
 discontinuity, run :program:`build_poly` as follows:
 
 .. code-block:: console
-                         
+
    $ $GYRE_DIR/bin/build_poly --n_poly=3,1.5 --z_b=1.4 --Delta_b=-0.5 --dz=0.01 poly.composite.h5
 
 This model, written to the file :file:`poly.composite.h5`, is visualized in the figure below.

--- a/docs/source/appendices/support-tools/eval-lambda.rst
+++ b/docs/source/appendices/support-tools/eval-lambda.rst
@@ -14,7 +14,7 @@ Synopsis
 
 Description
 -----------
-	     
+
 The :program:`eval_lambda` tool evaluates the eigenvalue
 :math:`\lambda` appearing in Laplace's tidal equations (see the
 :ref:`osc-rot` section), over a grid :math:`\{q\}` of spin parameter
@@ -88,7 +88,7 @@ Options
 .. option:: --n=N
 
    Number of points in grid.
-   
+
 .. option:: --log
 
    Use logarithmic grid spacing.

--- a/docs/source/appendices/support-tools/poly-to-fgong.rst
+++ b/docs/source/appendices/support-tools/poly-to-fgong.rst
@@ -14,7 +14,7 @@ Synopsis
 
 Description
 -----------
-   
+
 The :program:`poly_to_fgong` tool converts :ref:`polytropic stellar
 models <poly-models>` in the :ref:`POLY <poly-file-format>` format, to
 :ref:`evolutionary models <evol-models>` in the FGONG format. In this

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ html_theme_options = {
 }
 
 # CSS
-html_css_files = ["theme_overrides.css"] 
+html_css_files = ["theme_overrides.css"]
 
 # Set master doc
 master_doc = 'index'
@@ -156,8 +156,8 @@ for key, value in macros.items():
         mathjax_macros[key] = value
         latex_preamble += f'\\newcommand{{\\{key}}}{{{value}}}\n'
 
-mathjax3_config = {                  
-    'tex': { 
+mathjax3_config = {
+    'tex': {
         'macros': mathjax_macros
     }
 }
@@ -179,7 +179,7 @@ intersphinx_disabled_reftypes = ["std:doc"]
 
 # Equation number formatting
 math_eqref_format = '{number}'
-                       
+
 # Spelling
 spelling_word_list_filename='spelling_wordlist.txt'
 spelling_filters=['sphinxcontrib.spelling.filters.ContractionFilter']

--- a/docs/source/exts/ads_cite.py
+++ b/docs/source/exts/ads_cite.py
@@ -19,7 +19,7 @@ def build_cite(rawtext, ref, lineno, inliner, options, template):
         year = year_str[0]
     else:
         year = ads_data[ref].year
-        
+
     if len(ads_data[ref].author) == 1:
         author = format(ads_data[ref].author[0].split(',')[0])
     elif len(ads_data[ref].author) == 2:
@@ -89,7 +89,7 @@ def setup(app):
     app.add_role('ads_citealp', ads_citealp)
     app.add_role('ads_citeauthor', ads_citeauthor)
     app.add_role('ads_citeyear', ads_citeyear)
-    
+
     return {
         'version': '0.1',
     }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ oscillations, similar numerical techniques can be brought to bear.
    user-guide/advanced-usage.rst
    user-guide/faq.rst
    user-guide/troubleshooting.rst
-   
+
 .. toctree::
    :caption: Reference Guide
    :name: ref-guide

--- a/docs/source/ref-guide/input-files.rst
+++ b/docs/source/ref-guide/input-files.rst
@@ -27,4 +27,3 @@ follows, and the group ends with a slash ``/``.
    input-files/rot-params
    input-files/scan-params
    input-files/tidal-params
-

--- a/docs/source/ref-guide/input-files/grid-params.rst
+++ b/docs/source/ref-guide/input-files/grid-params.rst
@@ -36,10 +36,10 @@ the spatial grid, as follows:
 
 :nml_n:`dx_min` (default :nml_v:`SQRT(EPSILON(1._WP))`)
   Minimum spacing of grid points
-  
+
 :nml_n:`dx_max` (default :nml_v:`HUGE(0._WP)`)
   Maximum spacing of grid points
-  
+
 :nml_n:`n_iter_max` (default :nml_v:`32`)
   Maximum number of refinement iterations
 

--- a/docs/source/ref-guide/input-files/mode-params.rst
+++ b/docs/source/ref-guide/input-files/mode-params.rst
@@ -7,7 +7,7 @@ The :nml_g:`mode` namelist group defines mode parameters, as follows:
 
 :nml_n:`l` (default :nml_v:`0`)
   Harmonic degree :math:`\ell`
-  
+
 :nml_n:`m` (default :nml_v:`0`)
   Azimuthal order :math:`m`
 

--- a/docs/source/ref-guide/input-files/model-params.rst
+++ b/docs/source/ref-guide/input-files/model-params.rst
@@ -11,10 +11,10 @@ follows:
 
   - :nml_v:`'HOM'` : :ref:`Homogeneous compressible model <hom-models>`
   - :nml_v:`'POLY'` : :ref:`Polytropic model <poly-models>` read from external file
-  - :nml_v:`'ANAPOLY_0'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=0` 
-  - :nml_v:`'ANAPOLY_1'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=1` 
-  - :nml_v:`'ANAPOLY_5'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=5` 
-  - :nml_v:`'ANAPOLY_5_1'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=5,1` 
+  - :nml_v:`'ANAPOLY_0'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=0`
+  - :nml_v:`'ANAPOLY_1'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=1`
+  - :nml_v:`'ANAPOLY_5'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=5`
+  - :nml_v:`'ANAPOLY_5_1'` : :ref:`Analytic polytropic model <anapoly-models>` with :math:`\npoly=5,1`
   - :nml_v:`'EVOL'` : :ref:`Evolutionary model <evol-models>` read from external file
 
 :nml_n:`file`
@@ -35,7 +35,7 @@ follows:
 
 :nml_n:`data_format` (default :nml_v:`''`, indicates auto-select)
   Fortran format specifier for data read from OSC-, FGONG- and FAMDL-format files
-  
+
 :nml_n:`deriv_type` (default :nml_v:`'MONO'`)
   Cubic interpolation derivatives type (when :nml_n:`model_type`\ =\ :nml_v:`'EVOL'`
   and :nml_n:`interp_type`\ =\ :nml_v:`'CUBIC'`); One
@@ -48,7 +48,7 @@ follows:
   First adiabatic exponent (when :nml_n:`model_type`\ =\ :nml_v:`'HOM'`\ \|\ :nml_v:`'ANAPOLY_*'`)
 
 :nml_n:`theta_s` (default :nml_n:`0`)
-  Surface value of polytropic dependent variable (when :nml_n:`model_type`\ =\ :nml_v:`'ANAPOLY_0'`\ \|\ :nml_v:`'ANAPOLY_1'`\ \|\ :nml_v:`'ANAPOLY_5'`) 
+  Surface value of polytropic dependent variable (when :nml_n:`model_type`\ =\ :nml_v:`'ANAPOLY_0'`\ \|\ :nml_v:`'ANAPOLY_1'`\ \|\ :nml_v:`'ANAPOLY_5'`)
 
 :nml_n:`x_match` (default :nml_n:`0.5`)
   Radial coordinate of match point between inner and outer regions (when :nml_n:`model_type`\ =\ :nml_v:`'ANAPOLY_5_1'`)
@@ -62,7 +62,7 @@ follows:
 
 :nml_n:`n` (default :nml_v:`10`)
   Number of points in model grid (when :nml_n:`model_type`\ =\ :nml_v:`'HOM'`\ \|\ :nml_v:`'ANAPOLY_*'`)
-       
+
 :nml_n:`s` (default :nml_v:`1`)
   Skewness parameter for model grid (when :nml_n:`model_type`\ =\
   :nml_v:`'HOM'`\ \|\ :nml_v:`'ANAPOLY_*'` and :nml_n:`grid_type`\ =\ :nml_v:`'GEO'`\ \|\
@@ -70,7 +70,7 @@ follows:
 
 :nml_n:`x_i` (default :nml_v:`0`)
   Inner boundary coordinate of model grid (when :nml_n:`model_type`\ =\ :nml_v:`'HOM'`\ \|\ :nml_v:`'ANAPOLY_*'`)
-    
+
 :nml_n:`x_o` (default :nml_v:`1`)
   Outer boundary coordinate of model grid (when :nml_n:`model_type`\ =\ :nml_v:`'HOM'`\ \|\ :nml_v:`'ANAPOLY_*'`)
 
@@ -103,4 +103,4 @@ follows:
 :nml_n:`use_nabla_rad` (default :nml_v:`.FALSE.`)
   Use :math:`\nabrad` to calculate the radiative luminosity
   (when :nml_n:`model_type`\ =\ :nml_v:`'EVOL'` \& :nml_n:`file_format`\ =\ :nml_v:`'OSC'`)
-  
+

--- a/docs/source/ref-guide/input-files/num-params.rst
+++ b/docs/source/ref-guide/input-files/num-params.rst
@@ -34,7 +34,7 @@ used. Allowable fields are:
 
 :nml_n:`n_iter_max` (default :nml_v:`50`)
   Maximum number of iterations in root-finding algorithm
-  
+
 :nml_n:`matrix_type` (default :nml_v:`'BLOCK`')
   Storage type of system matrix; one of
 
@@ -51,7 +51,7 @@ used. Allowable fields are:
 :nml_n:`ad_search` (default :nml_v:`'BRACKET'`)
   Initial search method for adiabatic calculations; one of
 
-  - :nml_v:`'BRACKET'` : Bracket sign changes in the discriminant function 
+  - :nml_v:`'BRACKET'` : Bracket sign changes in the discriminant function
 
 :nml_n:`nad_search` (default :nml_v:`'AD'`)
   Initial search method for non-adiabatic calculations; one of
@@ -61,6 +61,6 @@ used. Allowable fields are:
   - :nml_v:`'CONTOUR'` : Find intersections between real and imaginary zero-contours of the discriminant function
 
   See the :ref:`non-ad-osc` chapter for more details about these search methods.
-    
+
 :nml_n:`tag_list` (default :nml_v:`''`, which matches all)
    Comma-separated list of :nml_g:`mode` tags to match

--- a/docs/source/ref-guide/input-files/osc-params.rst
+++ b/docs/source/ref-guide/input-files/osc-params.rst
@@ -84,7 +84,7 @@ The :nml_g:`osc` namelist group defines oscillation parameters, as follows:
 :nml_n:`alpha_rht` (default :nml_v:`0.`)
   Scaling factor for time-dependent term in radiative heat equation (see the
   :math:`\alpharht` entry in the :ref:`osc-physics-switches` section)
-  
+
 :nml_n:`alpha_trb` (default :nml_v:`0.`)
    Scaling factor for the turbulent mixing length (see the
    :math:`\alphatrb` entry in the :ref:`osc-physics-switches`
@@ -130,13 +130,13 @@ The :nml_g:`osc` namelist group defines oscillation parameters, as follows:
 
 :nml_n:`x_atm` (default :nml_v:`-1`, implying outer grid point)
   Fractional radius for convection-zone crossover point of :math:`\pi/\gamma` modes (isolated p and g modes; see :ads_citealp:`ong:2020`)
-   
+
 :nml_n:`adiabatic` (default :nml_v:`.TRUE.`)
   Flag to perform adiabatic calculations
-  
+
 :nml_n:`nonadiabatic` (default :nml_v:`.FALSE.`)
   Flag to perform non-adiabatic calculations
-  
+
 :nml_n:`quasiad_eigfuncs` (default :nml_v:`.FALSE.`)
   Flag to calculate quasi-adiabatic entropy/luminosity eigenfunctions
   during adiabatic calculations

--- a/docs/source/ref-guide/input-files/rot-params.rst
+++ b/docs/source/ref-guide/input-files/rot-params.rst
@@ -45,4 +45,4 @@ follows:
 .. rubric:: Footnotes
 
 .. [#only-D] This option is available only for stellar models with :ref:`D capability <model-caps>`
-  
+

--- a/docs/source/ref-guide/input-files/scan-params.rst
+++ b/docs/source/ref-guide/input-files/scan-params.rst
@@ -25,7 +25,7 @@ follows:
 
 :nml_n:`freq_max` (default :nml_v:`10`)
   Maximum frequency, when :nml_n:`grid_type` is :nml_v:`'LINEAR'` or :nml_v:`'INVERSE'`
-  
+
 :nml_n:`n_freq` (default :nml_v:`10`)
   Number of frequency points, when :nml_n:`grid_type` is :nml_v:`'LINEAR'` or :nml_v:`'INVERSE'`
 

--- a/docs/source/ref-guide/osc-equations.rst
+++ b/docs/source/ref-guide/osc-equations.rst
@@ -18,4 +18,3 @@ frontends are obtained from the basic equations of stellar structure.
    osc-equations/rot-effects.rst
    osc-equations/conv-effects.rst
    osc-equations/tidal-effects.rst
-   

--- a/docs/source/ref-guide/osc-equations/bound-conditions.rst
+++ b/docs/source/ref-guide/osc-equations/bound-conditions.rst
@@ -21,7 +21,7 @@ regularity conditions
    \ell \tPhi' - r \deriv{\tPhi'}{r} = 0, \\
    \delta \tS = 0.
    \end{aligned}
-   
+
 Sometimes it's desirable that the inner boundary is instead placed at
 :math:`r > 0` --- for instance, to excise the stellar core from
 the oscillation calculations. Then, there is much more flexibility in the
@@ -52,7 +52,7 @@ boundary condition
    \delta \tP = 0.
 
 Finally, the thermal boundary condition can be derived from the
-equation 
+equation
 
 .. math::
 
@@ -99,7 +99,7 @@ are given by
    \left. \frac{\delta \tS}{\cP} \right|^{+} - \left. \frac{\delta \tS}{\cP} \right|^{-} &= - \left( \nabad^{+} - \nabad^{-} \right) \frac{\delta \tP}{P}, \\
    \left. \deriv{\tPhi'}{r} \right|^{+} - \left. \deriv{\tPhi'}{r} \right|^{-} &= - 4 \pi G \left( \rho^{+} - \rho^{-} \right) \txir. \\
    \end{aligned}
-   
+
 Here, + (-) superscripts indicate quantities evaluated on the inner
 (outer) side of the discontinuity. The first of these conditions
 arises from applying equation (:eq:`e:osc-eul-lag`) to the pressure
@@ -113,4 +113,4 @@ and Poisson equations (:eq:`e:osc-sep-cont` and
 
 .. [#continuous] This is to ensure that the fluid doesn't 'tear', and
                  that pressure, potential and temperature gradients are
-		 continuous.
+                 continuous.

--- a/docs/source/ref-guide/osc-equations/dimless-form.rst
+++ b/docs/source/ref-guide/osc-equations/dimless-form.rst
@@ -30,7 +30,7 @@ The independent variable is the fractional radius :math:`x \equiv r/\Rstar`
    \end{aligned}
 
 (with :math:`\Lstar` the stellar luminosity).
-   
+
 .. _osc-dimless-eqns:
 
 Oscillation Equations
@@ -54,7 +54,7 @@ The dimensionless oscillation equations are
    \alphagrv y_{4} +
    \upsT \, y_{5}, \\
    %
-   x \deriv{y_{3}}{x} &= 
+   x \deriv{y_{3}}{x} &=
    \alphagrv \left( 3 - U - \ell \right) y_{3} +
    \alphagrv y_{4} \\
    %
@@ -65,7 +65,7 @@ The dimensionless oscillation equations are
    \alphagrv (U + \ell - 2) y_{4}
    - \alphagrv \upsT \, U y_{5}, \\
    %
-   x \deriv{y_{5}}{x} &= 
+   x \deriv{y_{5}}{x} &=
    \frac{V}{\frht} \left[ \nabad (U - c_{1}\omega^{2}) - 4 (\nabad - \nabla) + \ckapad V \nabla + \cdif \right] y_{1} + \mbox{} \\
    &
    \frac{V}{\frht} \left[ \frac{\ell(\ell+1)}{c_{1} \omega^{2}} (\nabad - \nabla) - \ckapad V \nabla - \cdif \right] y_{2} + \mbox{} \\
@@ -113,7 +113,7 @@ replaced by
    x \deriv{y_{1}}{x} &=
    \left( \frac{V}{\Gammi} - 1 \right) y_{1} - \frac{V}{\Gamma_{1}} y_{2}, \\
    %
-   x \deriv{y_{2}}{x} &= 
+   x \deriv{y_{2}}{x} &=
    \left( c_{1} \omega^{2} + U - \As \right) y_{1} + \left( 3 - U + \As \right) y_{2}.
    \end{aligned}
 
@@ -144,7 +144,7 @@ conditions above are replaced with zero radial displacement
 conditions,
 
 .. math::
-   
+
    \begin{aligned}
    y_{1} &= 0, \\
    y_{4} &= 0.
@@ -188,7 +188,7 @@ above is replaced by the :ads_citet:`dziembowski:1971` outer boundary condition,
    y_{2} +
    V^{-1} \left[ \frac{\ell(\ell+1)}{c_{1} \omega^{2}} - l - 1 \right] y_{3}
    = 0.
-   
+
 When :nml_n:`outer_bound`\ =\ :nml_v:`'UNNO'` or :nml_v:`'JCD'`, the
 first condition is replaced by the (possibly-leaky) outer boundary
 conditions described by :ads_citet:`unno:1989` and
@@ -207,7 +207,7 @@ Internal Boundaries
 Across density discontinuities, GYRE applies the boundary conditions
 
 .. math::
-   
+
    \begin{aligned}
    U^{+} y_{2}^{+} - U^{-} y_{2}^{-} &= y_{1} (U^{+} - U^{-}) \\
    y_{4}^{+} - y_{4}^{-} &= -y_{1} (U^{+} - U^{-}) \\

--- a/docs/source/ref-guide/osc-equations/fluid-equations.rst
+++ b/docs/source/ref-guide/osc-equations/fluid-equations.rst
@@ -63,7 +63,7 @@ to be functions of the pressure and entropy:
 
    \epsnuc = \epsnuc(P, S), \qquad
    \kappa = \kappa(P, S).
-   
+
 .. rubric:: Footnotes
 
 .. [#choice] This may seem like a strange choice, but it simplifies

--- a/docs/source/ref-guide/osc-equations/linear-equations.rst
+++ b/docs/source/ref-guide/osc-equations/linear-equations.rst
@@ -29,7 +29,7 @@ the equilibrium state as
 
 .. math::
 
-   T \pderiv{\delta S}{t} = \delta \epsnuc - 
+   T \pderiv{\delta S}{t} = \delta \epsnuc -
    \delta \left( \frac{1}{\rho} \nabla \cdot \vFrad \right),
 
 where the heating term :math:`\delta (\rho^{-1} \nabla \cdot \vFcon)`
@@ -110,4 +110,3 @@ The :math:`(\rho,T)` and :math:`(P,S)` pairs of partials are related by
              approximation. GYRE offers multiple ways to freeze
              convection; see the :ref:`osc-conv` section for further
              details.
-   

--- a/docs/source/ref-guide/osc-equations/rot-effects.rst
+++ b/docs/source/ref-guide/osc-equations/rot-effects.rst
@@ -184,8 +184,8 @@ boundary.
 .. rubric:: Footnotes
 
 .. [#gyre-tides] Currently the TAR cannot be used with the
-		 :program:`gyre_tides` frontend, because it doesn't play well with
-		 forcing by the tidal potential :math:`\PhiT`.
+      :program:`gyre_tides` frontend, because it doesn't play well with
+      forcing by the tidal potential :math:`\PhiT`.
 
 .. [#harmonic-deg] The harmonic degree isn't formally a 'good' quantum
                    number in the TAR; however, it can still be used to

--- a/docs/source/ref-guide/osc-equations/sep-equations.rst
+++ b/docs/source/ref-guide/osc-equations/sep-equations.rst
@@ -71,7 +71,7 @@ is the Lagrangian perturbation to the radiative luminosity. The radial part of t
 .. math::
 
    \delta\tFradr = \left[
-   4 \frac{\delta \tT}{T} - \frac{\delta\trho}{\rho} - \frac{\delta\tkappa}{\kappa} + 
+   4 \frac{\delta \tT}{T} - \frac{\delta\trho}{\rho} - \frac{\delta\tkappa}{\kappa} +
    \frac{\sderiv{(\delta \tT/T)}{\ln r}}{\sderiv{\ln T}{\ln r}} \right] \Fradr.
 
 Finally, the thermodynamic, nuclear and opacity relations become

--- a/docs/source/ref-guide/osc-equations/tidal-effects.rst
+++ b/docs/source/ref-guide/osc-equations/tidal-effects.rst
@@ -38,7 +38,7 @@ of partial tidal potentials defined by
 (the summation over :math:`\ell` and :math:`m` comes from a multipolar
 space expansion of the potential, and the summation over :math:`k`
 from a Fourier time expansion). Here,
-   
+
 .. math::
 
    \epsT = \left( \frac{\Rstar}{a} \right)^{3} q = \frac{\Oorb^{2} \Rstar^{3}}{G\Mstar} \frac{q}{1+q}
@@ -108,7 +108,7 @@ where
 
 .. math::
    :label: e:tidal-part-pot
-   
+
    \tPhiTlmk \equiv - \epsT \,
    \frac{G\Mstar}{\Rstar} \,
    \cbar_{\ell,m,k}

--- a/docs/source/ref-guide/output-files/detail-files.rst
+++ b/docs/source/ref-guide/output-files/detail-files.rst
@@ -182,7 +182,7 @@ Classification & Validation
      - frequency weight function :math:`[G\Mstar^{2}/\Rstar]`;
        evaluated from the integrand in eqn. (A5) of
        :ads_citet:`townsend:2025` with :math:`n'=n`
-       
+
    * - :nml_v:`zeta`
      - :math:`\zeta`
      - complex
@@ -413,7 +413,7 @@ Rotation
    * - :nml_v:`Omega_rot_ref`
      - :math:`\Omega_{\rm rot,ref}`
      - real
-     - rotation angular frequency at reference location:math:`[\sqrt{G\Mstar/\Rstar^{3}}]`
+     - rotation angular frequency at reference location :math:`[\sqrt{G\Mstar/\Rstar^{3}}]`
    * - :nml_v:`Omega_rot`
      - :math:`\Orot`
      - real(:nml_v:`n`)
@@ -510,7 +510,7 @@ Stellar Structure
    * - :nml_v:`dnabla_ad`\ [#only-N]_
      - :math:`\dnabad`
      - real(:nml_v:`n`)
-     - logarithmic derivative of adiabatic temperature gradient 
+     - logarithmic derivative of adiabatic temperature gradient
    * - :nml_v:`beta_rad`\ [#only-D]_
      - :math:`\beta`
      - real(:nml_v:`n`)
@@ -586,7 +586,7 @@ Stellar Structure
      - :math:`T`
      - real(:nml_v:`n`)
      - temperature :math:`[\kelvin]`
-       
+
 Tidal Response
 --------------
 
@@ -669,5 +669,3 @@ Note that these items are available only when using :program:`gyre_tides`.
 .. [#only-D] This option is available only for stellar models with :ref:`D capability <model-caps>`
 
 .. [#only-P] This option is available only for polytrope models (`'HOM'`, `'POLY'`, `'ANAPOLY_*'`)
-	     
-		

--- a/docs/source/ref-guide/output-files/file-formats.rst
+++ b/docs/source/ref-guide/output-files/file-formats.rst
@@ -10,7 +10,7 @@ the :ref:`output-params` section). Possible choices are:
 
 * :nml_v:`'HDF'` : A binary format based on the `HDF5
   <https://support.hdfgroup.org/HDF5/whatishdf5.html>`__ format
-  
+
 * :nml_v:`'TXT'` : A text format modeled after
   MESA's `profile file format <http://mesa.sourceforge.net/output.html>`__
 

--- a/docs/source/ref-guide/output-files/summary-files.rst
+++ b/docs/source/ref-guide/output-files/summary-files.rst
@@ -140,7 +140,7 @@ Classification & Validation
 
 Perturbations
 -------------
-  
+
 .. list-table::
    :header-rows: 1
    :widths: 15 10 10 65
@@ -349,7 +349,7 @@ Note that these items are available only when using :program:`gyre_tides`.
    * - :nml_v:`R_a`
      - :math:`R/a`
      - real(:nml_v:`n_row`)
-     - ratio of primary radius to orbital semi-major axis 
+     - ratio of primary radius to orbital semi-major axis
    * - :nml_v:`cbar`
      - :math:`\cbar_{\ell,m,k}`
      - real(:nml_v:`n_row`)

--- a/docs/source/ref-guide/stellar-models.rst
+++ b/docs/source/ref-guide/stellar-models.rst
@@ -18,6 +18,3 @@ equilibrium stellar configuration.
    stellar-models/mesa-file-format.rst
    stellar-models/gsm-file-format.rst
    stellar-models/poly-file-format.rst
-   
-
-

--- a/docs/source/ref-guide/stellar-models/evol-models.rst
+++ b/docs/source/ref-guide/stellar-models/evol-models.rst
@@ -59,7 +59,7 @@ table below.
 
 Interpolation
 -------------
-  
+
 Cubic spline interpolation is used to evaluate data between model grid
 points. The :nml_n:`deriv_type` parameter in the :nml_g:`model`
 namelist group controls how the spline derivatives are set up.

--- a/docs/source/ref-guide/stellar-models/gsm-file-format-v0.00.rst
+++ b/docs/source/ref-guide/stellar-models/gsm-file-format-v0.00.rst
@@ -61,7 +61,7 @@ Data items in the root HDF5 group of version-0.00 GSM-format files are as follow
      - :math:`T`
      - dataset
      - real (:code:`n`)
-     - temperature [:math:`\kelvin`]       
+     - temperature [:math:`\kelvin`]
    * - :code:`N2`
      - :math:`N^{2}`
      - dataset

--- a/docs/source/user-guide/advanced-usage/including-rotation.rst
+++ b/docs/source/user-guide/advanced-usage/including-rotation.rst
@@ -18,7 +18,7 @@ There are two different ways to define the rotation angular frequency
   obtained from the stellar model. If the model doesn't have this
   capability (see the :ref:`model-caps` section), then :math:`\Orot`
   is set to zero throughout the star.
-  
+
 * If :nml_n:`Omega_rot_source` = :nml_v:`'UNIFORM'`, then uniform
   rotation is assumed with a spatially constant :math:`\Orot` set by
   the :nml_n:`Omega_rot` and :nml_n:`Omega_rot_units` parameters.

--- a/docs/source/user-guide/advanced-usage/secular-rates.py
+++ b/docs/source/user-guide/advanced-usage/secular-rates.py
@@ -9,18 +9,18 @@ s = pg.read_output('summary.h5')
 
 sg = s.group_by('id').groups[0]
 
-Omega_orb = sg['Omega_orb']               
+Omega_orb = sg['Omega_orb']
 R_a = sg['R_a']
 q = sg['q']
 
 eps_T = R_a**3*q
-    
+
 l = sg['l']
 m = sg['m']
 k = sg['k']
 
 cbar = sg['cbar']
-        
+
 Fbar = -0.5*sg['eul_Phi_ref']/(cbar*eps_T)
 
 x = sg['x_ref']
@@ -49,17 +49,17 @@ for i in range(len(kap)):
 
 # Semi-major axis (units of R per dynamical timescale)
 
-a_dot = np.sum(4. * Omega_orb * q / R_a * 
+a_dot = np.sum(4. * Omega_orb * q / R_a *
     (R_a)**(l+3) * (x)**(l+1) * kap * Fbar.imag * Gbar_2)
 
 # Eccentricity (units of per dynamical timescale)
 
-e_dot = np.sum(4. * Omega_orb * q * 
+e_dot = np.sum(4. * Omega_orb * q *
     (R_a)**(l+3) * (x)**(l+1) * kap * Fbar.imag * Gbar_3)
 
 # Argument of periastron (units of radians per dynamical timescale)
 
-pom_dot = np.sum(4. * Omega_orb * q * 
+pom_dot = np.sum(4. * Omega_orb * q *
     (R_a)**(l+3) * (x)**(l+1) * kap * Fbar.real * Gbar_1)
 
 # Angular momentum (units of GM^2/R)

--- a/docs/source/user-guide/advanced-usage/tidal-forcing.rst
+++ b/docs/source/user-guide/advanced-usage/tidal-forcing.rst
@@ -98,5 +98,3 @@ torque. The expression for :code:`e_dot` mirrors equation (23) of
 :ads_citet:`sun:2023`, and for :code:`J_dot` equation (25) `ibid.`
 
 .. literalinclude:: secular-rates.py
-		    
-

--- a/docs/source/user-guide/example-walkthrough.rst
+++ b/docs/source/user-guide/example-walkthrough.rst
@@ -60,7 +60,7 @@ of the more-important aspects of the file above:
 * the :nml_g:`model` namelist group tells :program:`gyre` to read an evolutionary
   model, in :ref:`MESA format <mesa-file-format>`, from the file
   :file:`spb.mesa`;
-* the two :nml_g:`mode` namelist groups tells :program:`gyre` to search first for dipole (:math:`\ell=1`) and then 
+* the two :nml_g:`mode` namelist groups tells :program:`gyre` to search first for dipole (:math:`\ell=1`) and then
   quadrupole (:math:`\ell=2`) modes;
 * the :nml_g:`osc` namelist group tells :program:`gyre` to assume,
   when setting up the outer boundary conditions in the oscillation
@@ -83,7 +83,7 @@ Running gyre
 With the hard work done, it's now trivial to run :program:`gyre`:
 
 .. code-block:: console
-			 
+
    $ $GYRE_DIR/bin/gyre gyre.in
 
 As the frontend runs (on multiple cores, if you have a multi-core machine;
@@ -136,7 +136,7 @@ a mode that :program:`gyre` has successfully found:
 .. literalinclude:: example-walkthrough/gyre.out
    :language: console
    :start-at: Root Solving
-   :end-before: Mode Search	      
+   :end-before: Mode Search
 
 The columns appearing are as follows:
 
@@ -145,7 +145,7 @@ The columns appearing are as follows:
 
 ``m``
   azimuthal order :math:`m`
-  
+
 ``n_pg``
   radial order :math:`n` (in the Eckart-Osaki-:ads_citeauthor:`scuflaire:1974`-:ads_citeauthor:`takata:2006b` scheme)
 
@@ -198,4 +198,3 @@ output files are written:
 
 The :ref:`interpreting-output` chapter discusses how to read and analyze
 these files.
-  

--- a/docs/source/user-guide/faq.rst
+++ b/docs/source/user-guide/faq.rst
@@ -64,4 +64,3 @@ Why Does...
   This behavior is typically caused by overflow of the OpenMP stack
   (for more info see `here <https://stackoverflow.com/questions/13870564/gfortran-openmp-segmentation-fault-occurs-on-basic-do-loop>`__).
   Try setting the :envvar:`OMP_STACKSIZE` environment variable to 500K or 1M.
-

--- a/docs/source/user-guide/frontends.rst
+++ b/docs/source/user-guide/frontends.rst
@@ -14,4 +14,3 @@ there are others available focused on different kinds of task.
 
    frontends/gyre.rst
    frontends/gyre_tides.rst
-

--- a/docs/source/user-guide/frontends/gyre.rst
+++ b/docs/source/user-guide/frontends/gyre.rst
@@ -53,7 +53,7 @@ should appear in namelist input files for :program:`gyre`.
    * - :ref:`output-params`
      - :nml_g:`ad_output`
      - 1
-   * - 
+   * -
      - :nml_g:`nad_output`
      - 1
    * - :ref:`rot-params`

--- a/docs/source/user-guide/frontends/gyre_tides.rst
+++ b/docs/source/user-guide/frontends/gyre_tides.rst
@@ -61,7 +61,7 @@ should appear in namelist input files for :program:`gyre_tides`.
    * - :ref:`tidal-params`
      - :nml_g:`tide`
      - :math:`\geq 1`
-       
+
 .. rubric:: Footnotes
 
 .. [#last] While the input file can contain one or more of the

--- a/docs/source/user-guide/interpreting-output.rst
+++ b/docs/source/user-guide/interpreting-output.rst
@@ -123,7 +123,7 @@ them, the table rows can be grouped by harmonic degree:
    plt.legend()
 
 The resulting plot, in :numref:`fig-freq-grouped`, looks much better.
-   
+
 .. _fig-freq-grouped:
 
 .. figure:: interpreting-output/fig_freq_grouped.svg
@@ -143,7 +143,7 @@ Now let's take a look at one of the detail files, for the mode with
 data into an :external:py:class:`astropy.table.Table` object:
 
 .. code-block:: python
-   
+
    # Read data from a GYRE detail file
 
    d = pg.read_output('detail.l1.n-7.h5')

--- a/docs/source/user-guide/numerical-methods.rst
+++ b/docs/source/user-guide/numerical-methods.rst
@@ -19,4 +19,3 @@ eigenfunctions.
    numerical-methods/stretched-string.rst
    numerical-methods/from-string-to-gyre.rst
    numerical-methods/limitations.rst
-

--- a/docs/source/user-guide/numerical-methods/from-string-to-gyre.rst
+++ b/docs/source/user-guide/numerical-methods/from-string-to-gyre.rst
@@ -9,7 +9,7 @@ oscillation equations. The full details of :program:`gyre`'s approach
 are laid out in :ads_citet:`townsend:2013`; in this section we briefly
 summarize it, highlighting similarities and differences with the
 stretched-string problem.
-	   
+
 Separation
 ----------
 
@@ -93,7 +93,7 @@ The linear system can be written in the same form
 
 .. math::
 
-   \vu = 
+   \vu =
    \begin{pmatrix}
    \vty_{1} \\
    \vty_{2} \\
@@ -107,7 +107,7 @@ block-staircase matrix with components
 
 .. math::
 
-   \mS = 
+   \mS =
    \begin{pmatrix}
    \subin{\mB} & \mz & \cdots & \mz & \mz \\
    -\mY_{2;1} & \mI & \cdots & \mz & \mz \\

--- a/docs/source/user-guide/numerical-methods/stretched-string.rst
+++ b/docs/source/user-guide/numerical-methods/stretched-string.rst
@@ -130,7 +130,7 @@ Then, the second derivative of :math:`\tilde{y}` can be approximated to second o
 
    \left. \nderiv{\tilde{y}}{x}{2} \right|_{x=x_{j}} \approx \frac{\tilde{y}_{j+1} - 2 \tilde{y}_{j} + \tilde{y}_{j-1}}{\Delta x^{2}}
    \qquad (2 \leq j \leq N-1).
-   
+
 This allows us to replace the ODE with :math:`N-2` difference
 equations
 
@@ -147,13 +147,13 @@ Together with the two boundary conditions
    \tilde{y}_{N} = 0,
 
 we thus have a linear system of :math:`N` algebraic equations and :math:`N` unknowns.
-   
+
 Linear System
 -------------
 
 To find solutions to the linear system, we first write it in matrix form as
 
-.. math:: 
+.. math::
    :label: linear-sys
 
    \mS \vu = \mathbf{0},
@@ -162,7 +162,7 @@ where :math:`\vu` is the vector with components
 
 .. math::
 
-   \vu = 
+   \vu =
    \begin{pmatrix}
    \tilde{y}_{1} \\
    \tilde{y}_{2} \\
@@ -176,7 +176,7 @@ with components
 
 .. math::
 
-   \mS = 
+   \mS =
    \begin{pmatrix}
    1 & 0 & 0 & \cdots & 0 & 0 & 0 \\
    1 & \sigma^{2} \tau^{2} - 2 & 1 & \cdots & 0 & 0 & 0 \\
@@ -185,7 +185,7 @@ with components
    0 & 0 & 0 & \cdots & 0 & 0 & 1
    \end{pmatrix}.
 
-Here we've introduced 
+Here we've introduced
 
 .. math::
 

--- a/docs/source/user-guide/preliminaries.rst
+++ b/docs/source/user-guide/preliminaries.rst
@@ -96,4 +96,3 @@ GYRE has been developed with financial support from the following grants:
 
 GYRE has also benefited greatly from contributions (code, bug
 reports, feature requests) from the academic community. Thanks, folks!
-

--- a/docs/source/user-guide/troubleshooting.rst
+++ b/docs/source/user-guide/troubleshooting.rst
@@ -13,7 +13,3 @@ GYRE operation, and steps that can be taken to resolve them.
    troubleshooting/missing-modes.rst
    troubleshooting/duplicated-modes.rst
    troubleshooting/long-runtimes.rst
-   
-
-
-	     

--- a/docs/source/user-guide/troubleshooting/missing-modes.rst
+++ b/docs/source/user-guide/troubleshooting/missing-modes.rst
@@ -37,7 +37,7 @@ mode eigenfrequencies:
   frame. So, be sure to also set :nml_n:`grid_frame` \ =\
   :nml_n:`'COROT_I'`\ \|\ :nml_n:`'COROT_O'` in the :nml_g:`scan`
   namelist group.
-  
+
 Next, try increasing the number of points in the frequency grids,
 simply by increasing the :nml_n:`n_freq` parameter in the
 :nml_g:`scan` namelist group(s).

--- a/docs/source/user-guide/understanding-grids/frequency-grids.rst
+++ b/docs/source/user-guide/understanding-grids/frequency-grids.rst
@@ -158,7 +158,7 @@ appearing in the expressions above, and the corresponding namelist
 parameters:
 
 .. list-table::
-   :widths: 30 30 
+   :widths: 30 30
    :header-rows: 1
 
    * - Symbol

--- a/docs/source/user-guide/understanding-grids/spatial-grids.rst
+++ b/docs/source/user-guide/understanding-grids/spatial-grids.rst
@@ -225,7 +225,7 @@ appearing in the expressions above, and the corresponding namelist
 parameters.
 
 .. list-table::
-   :widths: 30 30 
+   :widths: 30 30
    :header-rows: 1
 
    * - Symbol
@@ -245,7 +245,7 @@ parameters.
    * - :math:`\Delta x_{\rm min}`
      - :nml_n:`dx_min`
 
-.. _spatial-grids-rec:       
+.. _spatial-grids-rec:
 
 Recommended Values
 ------------------

--- a/models/poly/build_poly.py
+++ b/models/poly/build_poly.py
@@ -24,7 +24,7 @@ def build_poly(n_poly, Delta_b, z_b, Gamma_1, dz, toler, filename):
     subprocess.run(args)
 
 #
-            
+
 if __name__ == "__main__":
 
     Gamma_1 = 1.66666666666666667

--- a/src/tar/cheb_fit.py
+++ b/src/tar/cheb_fit.py
@@ -60,7 +60,7 @@ class ChebFit:
         n = len(self.f) - 1
 
         c = np.empty([n+1])
-   
+
         for k in range(0, n+1):
 
             c[k] = 0.
@@ -83,6 +83,6 @@ class ChebFit:
                 c[k] /= n
             else:
                 c[k] /= 0.5*n
-        
+
         return c
-    
+

--- a/src/tar/tar_fit.py
+++ b/src/tar/tar_fit.py
@@ -73,4 +73,4 @@ class TarFit:
             return q**2
         else:
             raise Exception('Invalid k')
-        
+

--- a/test/ad/poly/build_ref.py
+++ b/test/ad/poly/build_ref.py
@@ -23,7 +23,7 @@ def write_file (file, l, n, omega) :
 
     f.close()
 
-    
+
 # Build a reference file using analytical frequencies (from [Pek1938])
 
 def build_ref_0 (out_file, gamma) :
@@ -42,7 +42,7 @@ def build_ref_0 (out_file, gamma) :
     omega = np.empty(N, dtype=np.complex128)
 
     j = 0
-    
+
     for l_ in range(l_min, l_max+1) :
         for n_ in range(n_min, n_max+1) :
 
@@ -63,7 +63,7 @@ def build_ref_0 (out_file, gamma) :
 
     write_file(out_file, l, n, omega)
 
-    
+
 # Build a reference file using tabulated frequency data
 
 def build_ref (in_file, out_file, nu_ref, l_0) :
@@ -84,7 +84,7 @@ def build_ref (in_file, out_file, nu_ref, l_0) :
     omega = np.empty(N, dtype=np.complex128)
 
     j = 0
-    
+
     for l_ in range(l_min, l_max+1) :
         for i in range(len(d)):
             l[j] = l_

--- a/test/map/plot_map.py
+++ b/test/map/plot_map.py
@@ -8,25 +8,25 @@ import numpy as np
 # Read a discriminant map
 
 def read_map (filename):
-    
+
     import numpy as np
     import h5py as h5
-    
+
     f = h5.File(filename, 'r')
-    
+
     D_e = f['discrim_map_e'][...]
     D_f = f['discrim_map_f'][...]
-    
+
     log_D = 0.5*np.log10(D_f['re']**2 + D_f['im']**2) + D_e*np.log10(2.)
-    
+
     D_re = D_f['re']*2.**(D_e-np.min(D_e))
     D_im = D_f['im']*2.**(D_e-np.min(D_e))
-    
+
     omega_re = f['omega_re'][...]
     omega_im = f['omega_im'][...]
-    
+
     f.close()
-    
+
     return {'omega_re': omega_re,
             'omega_im': omega_im,
             'D_re': D_re,

--- a/test/reports/converg/report_converg.py
+++ b/test/reports/converg/report_converg.py
@@ -15,10 +15,10 @@ import gyre
 from colors import *
 
 from matplotlib.backends.backend_pdf import PdfPages
- 
+
 # Run parameters
 
-IVP_SOLVER = ['MAGNUS_GL2', 
+IVP_SOLVER = ['MAGNUS_GL2',
               'MAGNUS_GL4',
               'MAGNUS_GL6',
               'COLLOC_GL2',
@@ -52,19 +52,19 @@ def run_gyre (n_grid, l, ivp_solver, vars_set, summ_file) :
 &constants
 /
 &model
-	model_type = 'HOM'
+        model_type = 'HOM'
         grid_type = 'GEO'
         n = {n_grid:d}
         s = 1000
 /
 &mode
-	l = {l:d}
+        l = {l:d}
 /
 &osc
         variables_set = '{vars_set:s}'
 /
 &num
-	diff_scheme = '{ivp_solver:s}'
+        diff_scheme = '{ivp_solver:s}'
 /
 &scan
         grid_type = 'LINEAR'
@@ -76,15 +76,15 @@ def run_gyre (n_grid, l, ivp_solver, vars_set, summ_file) :
 &grid
 /
 &ad_output
-	summary_file = '{summ_file:s}'
-	summary_item_list = 'l,n_pg,n_p,n_g,omega'
+        summary_file = '{summ_file:s}'
+        summary_item_list = 'l,n_pg,n_p,n_g,omega'
 /
 &nad_output
 /
 '''.format(l=l, vars_set=vars_set, ivp_solver=ivp_solver, n_grid=n_grid, summ_file=summ_file))
 
     # Run gyre
-         
+
     os.system('./gyre gyre.in > /dev/null')
 #    os.remove('gyre.in')
 
@@ -174,8 +174,8 @@ def plot_data (pp, n_grid, domega, title) :
     pp.savefig(fig)
 
     plt.close(fig)
-    
-#                   
+
+
 
 def tex_escape (text) :
 
@@ -226,7 +226,7 @@ if __name__ == '__main__' :
 
                 # Read the summary results
 
-                if os.path.isfile('summary.h5') : 
+                if os.path.isfile('summary.h5') :
 
                     omega = read_summary('summary.h5', N_PG).real
                     os.remove('summary.h5')
@@ -237,7 +237,7 @@ if __name__ == '__main__' :
                     domega.append(np.abs(omega - eval_omega_ana(L, N_PG)))
 
             # Plot the results
-                    
+
             title = r'{{\tt ivp\_solver = {ivp_solver:s}}}, {{\tt variables\_set = {vars_set:s}}}'.format(ivp_solver=tex_escape(ivp_solver),
                                                                                                           vars_set=tex_escape(vars_set))
 


### PR DESCRIPTION
removing trailing white spaces and tabs in docs and python scripts so that Mesa's linter does not pick these up when gyre is built inside Mesa