### PR TITLE
First pass at a simple build-and-test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: build-and-test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out GYRE
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set up MESA SDK
+        uses: MESAHub/mesa/.github/actions/install-sdk-linux@main
+        with:
+          sdk: "26.6.1"
+
+      - name: Activate MESA SDK
+        run: echo "$MESASDK_ROOT/bin" >> $GITHUB_PATH
+
+      - name: Build GYRE
+        run: make -j
+
+      - name: Run test suite
+        run: |
+          pip install h5py
+          make test


### PR DESCRIPTION
While experimenting with #46, I noticed that this repo doesn't currently have CI set up in GitHub actions. This PR is a first pass at a basic workflow to build and test GYRE using Linux. This re-uses the [action in MESA to install the SDK on Linux](https://github.com/MESAHub/mesa/blob/main/.github/actions/install-sdk-linux/action.yml), which AFAICT should correctly handling caching the SDK so we don't download and unpack it each time, but I'm not sure I've configured it correctly.

I expect we'll want to expand on this in due course but I thought getting basic tests in was an important start.