### PR TITLE
Fixed call to files which have been renamed in GYRE version 7.2

### DIFF
--- a/src/tar/plot_tar_fit_coeffs.py
+++ b/src/tar/plot_tar_fit_coeffs.py
@@ -6,8 +6,8 @@ import sys
 import numpy as np
 import matplotlib.pyplot as plt
 
-import gyre_tar_fit
-import gyre_cheb_fit
+import tar_fit
+import cheb_fit
 
 # Arguments
 
@@ -31,7 +31,7 @@ ax.set_yscale('log')
 
 # Load the file
 
-tf = gyre_tar_fit.TarFit.load(infile)
+tf = tar_fit.TarFit.load(infile)
 
 # Plot coefficients
 


### PR DESCRIPTION
Small fix to reflect changes in file names that occurred in GYRE version 7.2.

**Note**:  File names in /gyre/src/tar/ are important for compatibility with the AMIGO software, which depends on these files (https://github.com/IvS-Asteroseismology/amigo). Due to changes to file names in GYRE version 7.2 that were not fully consistent across all files, GYRE versions 7.2 to 8.0 are not compatible with AMIGO. This unfortunately includes GYRE version 7.2.1, which is currently shipped with the latest version of MESA (24.08.1). I made a pull request to update AMIGO accordingly and point to the latest version of GYRE (9.X and later) for stable use, so this should not be an issue.